### PR TITLE
New converter for Repository.schemas

### DIFF
--- a/pass-core-object-service/src/main/java/org/eclipse/pass/object/converter/ListToURIStringConverter.java
+++ b/pass-core-object-service/src/main/java/org/eclipse/pass/object/converter/ListToURIStringConverter.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.object.converter;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.persistence.AttributeConverter;
+
+public class ListToURIStringConverter implements AttributeConverter<List<URI>, String> {
+    @Override
+    public String convertToDatabaseColumn(List<URI> attribute) {
+        return attribute == null || attribute.isEmpty() ? null :
+            attribute.stream().map(i -> i.toString()).collect(Collectors.joining(","));
+    }
+
+    @Override
+    public List<URI> convertToEntityAttribute(String dbData) {
+        return dbData == null || dbData.isEmpty() ? Collections.emptyList() :
+            Arrays.asList(dbData.split(",")).stream().map(URI::create).collect(Collectors.toList());
+    }
+}

--- a/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/Repository.java
+++ b/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/Repository.java
@@ -25,7 +25,7 @@ import javax.persistence.Table;
 
 import com.yahoo.elide.annotation.Include;
 import org.eclipse.pass.object.converter.IntegrationTypeToStringConverter;
-import org.eclipse.pass.object.converter.ListToStringConverter;
+import org.eclipse.pass.object.converter.ListToURIStringConverter;
 
 /**
  * Describes a Repository. A Repository is the target of a Deposit.
@@ -81,7 +81,7 @@ public class Repository extends PassEntity {
     /**
      * URLs that link to JSON schema documents describing the repository's metadata requirements
      */
-    @Convert(converter = ListToStringConverter.class)
+    @Convert(converter = ListToURIStringConverter.class)
     private List<URI> schemas = new ArrayList<>();
 
     /**


### PR DESCRIPTION
Local testing showed that if a Repository object was POSTed through JSON API, you'd get a ClassCastException from the Repository.schemas converter (ListToStringConverter) because the field is of type `List<URI>`

```
java.lang.ClassCastException: class java.net.URI cannot be cast to class java.lang.CharSequence (java.net.URI and java.lang.CharSequence are in module java.base of loader 'bootstrap')
        at java.base/java.lang.String.join(String.java:2442)
        at org.eclipse.pass.object.converter.ListToStringConverter.convertToDatabaseColumn(ListToStringConverter.java:26)
```

* Add new ListToURIStringConverter that will serialize/deserialize the URI list
* Update field annotation 