### PR TITLE
Remove unused DateTimeFormatters from unit tests.

### DIFF
--- a/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/GrantModelTests.java
+++ b/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/GrantModelTests.java
@@ -22,8 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.time.ZonedDateTime;
 
 import org.eclipse.pass.object.model.support.TestValues;
-import org.joda.time.format.DateTimeFormatter;
-import org.joda.time.format.ISODateTimeFormat;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -34,10 +32,6 @@ import org.junit.jupiter.api.Test;
  * @author Jim Martino
  */
 public class GrantModelTests {
-
-    private DateTimeFormatter dateFormatter = ISODateTimeFormat.dateTime().withZoneUTC();
-
-
     /**
      * Creates two identical Grants and checks the equals and hashcodes match.
      * Modifies one field on one of the Grants and verifies they no longer are

--- a/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/SubmissionEventModelTests.java
+++ b/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/SubmissionEventModelTests.java
@@ -24,8 +24,6 @@ import java.net.URI;
 import java.time.ZonedDateTime;
 
 import org.eclipse.pass.object.model.support.TestValues;
-import org.joda.time.format.DateTimeFormatter;
-import org.joda.time.format.ISODateTimeFormat;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -36,9 +34,6 @@ import org.junit.jupiter.api.Test;
  * @author Jim Martino
  */
 public class SubmissionEventModelTests {
-
-    private DateTimeFormatter dateFormatter = ISODateTimeFormat.dateTime().withZoneUTC();
-
     /**
      * Creates two identical SubmissionEvents and checks the equals and hashcodes match.
      * Modifies one field on one of the SubmissionEvents and verifies they no longer are

--- a/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/SubmissionModelTests.java
+++ b/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/SubmissionModelTests.java
@@ -26,8 +26,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.pass.object.model.support.TestValues;
-import org.joda.time.format.DateTimeFormatter;
-import org.joda.time.format.ISODateTimeFormat;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -40,10 +38,6 @@ import org.junit.jupiter.api.Test;
  * @author Jim Martino
  */
 public class SubmissionModelTests {
-
-    private DateTimeFormatter dateFormatter = ISODateTimeFormat.dateTime().withZoneUTC();
-
-
     /**
      * Creates two identical Submissions and checks the equals and hashcodes match.
      * Modifies one field on one of the submissions and verifies they no longer are


### PR DESCRIPTION
Just a small cleanup to unit tests removing some unused code.