### PR TITLE
Add Unpaywall DOI Lookup to pass-doi-service module

### DIFF
--- a/pass-core-doi-service/README.md
+++ b/pass-core-doi-service/README.md
@@ -1,7 +1,7 @@
 # pass-doi-service
 
-Service for accepting a DOI and returning a Journal ID and Crossref metadata for the DOI via the /journal endpoint, or 
-returning information about a manuscript from Unpaywall via the /manuscript endpoint.
+Service for accepting a DOI and returning a Journal ID and Crossref metadata for the DOI via the /doi/journal endpoint, or 
+returning information about a manuscript from Unpaywall via the /doi/manuscript endpoint.
 
 ## Description for the `/doi/journal` endpoint
 
@@ -39,6 +39,6 @@ corresponding locations on the web for manuscript PDFs related to the article re
 
 ### Configuration
 
-Just like the /journal endpoint, this service will look for an environment variable called PASS_DOI_SERVICE_MAILTO 
-to specify a value for the `email` query parameter on the Unpaywall request. In addition, we may supply values for XREF_BASEURL
+Just as for the /doi/journal endpoint, this service will look for an environment variable called PASS_DOI_SERVICE_MAILTO 
+to specify a value for the `email` query parameter on the Unpaywall request. In addition, we may supply values for XREF_BASEURI
 and UNPAYWALL_BASEURI, which default to `https://api.crossref.org/v1/works/` and `https://api.unpaywall.org/v2/` respectively.

--- a/pass-core-doi-service/README.md
+++ b/pass-core-doi-service/README.md
@@ -26,7 +26,7 @@ header on the Crossref request. Default value os `pass@jhu/edu`.
 
 ## Description for the `/doi/manuscript` endpoint
 
-This service accepts a journal DOI as a query parameter:
+This service accepts a manuscript DOI as a query parameter:
 
 `http://<host>:<port>/doi/manuscript?doi=<doi>`
 

--- a/pass-core-doi-service/README.md
+++ b/pass-core-doi-service/README.md
@@ -3,11 +3,11 @@
 Service for accepting a DOI and returning a Journal ID and Crossref metadata for the DOI via the /journal endpoint, or 
 returning information about a manuscript from Unpaywall via the /manuscript endpoint.
 
-## Description for the `/journal` endpoint
+## Description for the `/doi/journal` endpoint
 
 This service accepts a journal DOI as a query parameter:
 
-`http://<host>:<port>/journal?doi=<doi>`
+`http://<host>:<port>/doi/journal?doi=<doi>`
 
 DOIs must contain a form like `10.1234/ ...`
 If a DOI is of a longer URL form containing the string `doi.org/`, then we truncate the DOI to take everything after
@@ -22,19 +22,19 @@ as a result of the Crossref call.
 ### Configuration
 
 The service will look for an environment variable called PASS_DOI_SERVICE_MAILTO to specify a value on the User-Agent
-header on the Crossref request. Default value os `pss@jhu/edu`.
+header on the Crossref request. Default value os `pass@jhu/edu`.
 
-## Description for the `/manuscript` endpoint
+## Description for the `/doi/manuscript` endpoint
 
 This service accepts a journal DOI as a query parameter:
 
-`http://<host>:<port>/manuscript?doi=<doi>`
+`http://<host>:<port>/doi/manuscript?doi=<doi>`
 
 DOIs must contain a form like `10.1234/ ...`
 If a DOI is of a longer URL form containing the string `doi.org/`, then we truncate the DOI to take everything after
 this substring.
 
-The service validates the form of the doi - if it is valid, then we hit the Onpaywall API to get information about the
+The service validates the form of the doi - if it is valid, then we hit the Unpaywall API to get information about the
 corresponding locations on the web for manuscript PDFs related to the article referenced by the DOI.
 
 ### Configuration

--- a/pass-core-doi-service/README.md
+++ b/pass-core-doi-service/README.md
@@ -1,8 +1,9 @@
 # pass-doi-service
 
-Service for accepting a DOI and returning a Journal ID and Crossref metadata for the DOI
+Service for accepting a DOI and returning a Journal ID and Crossref metadata for the DOI via the /journal endpoint, or 
+returning information about a manuscript from Unpaywall via the /manuscript endpoint.
 
-## Description
+## Description for the `/journal` endpoint
 
 This service accepts a journal DOI as a query parameter:
 
@@ -18,7 +19,26 @@ corresponding journal. We then check to see if there is a
 containing the `journal-id` of the PASS journal, and a `crossref` object representing the data returned to the service
 as a result of the Crossref call.
 
-## Configuration
+### Configuration
 
 The service will look for an environment variable called PASS_DOI_SERVICE_MAILTO to specify a value on the User-Agent
-header on the Crossref request. 
+header on the Crossref request. Default value os `pss@jhu/edu`.
+
+## Description for the `/manuscript` endpoint
+
+This service accepts a journal DOI as a query parameter:
+
+`http://<host>:<port>/manuscript?doi=<doi>`
+
+DOIs must contain a form like `10.1234/ ...`
+If a DOI is of a longer URL form containing the string `doi.org/`, then we truncate the DOI to take everything after
+this substring.
+
+The service validates the form of the doi - if it is valid, then we hit the Onpaywall API to get information about the
+corresponding locations on the web for manuscript PDFs related to the article referenced by the DOI.
+
+### Configuration
+
+Just like the /journal endpoint, this service will look for an environment variable called PASS_DOI_SERVICE_MAILTO 
+to specify a value for the `email` query parameter on the Unpaywall request. In addition, we may supply values for XREF_BASEURL
+and UNPAYWALL_BASEURI, which default to `https://api.crossref.org/v1/works/` and `https://api.unpaywall.org/v2/` respectively.

--- a/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/ElideConnector.java
+++ b/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/ElideConnector.java
@@ -171,8 +171,11 @@ public class ElideConnector {
      * Crossref version if we don't have it already in PASS. Store the resulting object in PASS.
      *
      * @param journal - the Journal object generated from Crossref metadata
+     * @param passClient - the PASS client
      * @return the updated Journal object stored in PASS if the PASS object needs updating; null if we don't have
      * enough info to create a journal
+     *
+     * @throws IOException if the connection to Elide was unsuccessful
      */
     protected Journal updateJournalInPass(Journal journal, PassClient passClient) throws IOException {
         LOG.debug("GETTING NAME and  ISSNS for Journal with nme " + journal.getJournalName());
@@ -216,7 +219,11 @@ public class ElideConnector {
      *
      * @param name  the name of the journal to be found
      * @param issns the set of issns to find. we assume that the issns stored in the repo are of the format type:value
+     * @param passClient - the PASS client
      * @return the URI of the best match, or null in nothing matches
+     *
+     * @throws IOException if the connection to Elide was unsuccessful
+     *
      */
     protected Journal find(String name, List<String> issns, PassClient passClient) throws IOException {
 

--- a/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/ElideConnector.java
+++ b/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/ElideConnector.java
@@ -38,6 +38,10 @@ import org.eclipse.pass.object.model.Journal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * This class manages Journal objects related to a journal lookup on Crossref - creating or updating
+ * a Journal through the Elide interface when necessary
+ */
 public class ElideConnector {
     private static final Logger LOG = LoggerFactory.getLogger(ElideConnector.class);
 
@@ -89,7 +93,7 @@ public class ElideConnector {
 
     /**
      * Takes JSON which represents journal article metadata from Crossref
-     * and populates a new Journal object. Currently we take typed issns and the journal
+     * and populates a new Journal object. Currently, we take typed issns and the journal
      * name.
      *
      * @param metadata - the JSON metadata from Crossref
@@ -220,16 +224,14 @@ public class ElideConnector {
         //look for journals with this name
         String filter = RSQL.equals("journalName", name);
         PassClientResult<Journal> result = passClient.
-            selectObjects(new PassClientSelector<Journal>(Journal.class, 0, 100, filter, null));
-        result.getObjects().forEach(j -> {
-            foundList.add(j);
-        });
+            selectObjects(new PassClientSelector<>(Journal.class, 0, 100, filter, null));
+        foundList.addAll(result.getObjects());
 
         //commenting this out until we get a search filter that works for finding a string in a list of strings
         //look for journals with any of these issns
         /* if (!issns.isEmpty()) {
             for (String issn : issns) {
-                filter = RSQL.equals("issns", issn);
+                filter = RSQL.equals("issns", issn); //probably not the right call, not implemented yet
                 result = passClient.
                     selectObjects(new PassClientSelector<>(Journal.class, 0, 100, filter, null));
                 result.getObjects().forEach(j -> {

--- a/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/ElideConnector.java
+++ b/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/ElideConnector.java
@@ -41,6 +41,8 @@ import org.slf4j.LoggerFactory;
 /**
  * This class manages Journal objects related to a journal lookup on Crossref - creating or updating
  * a Journal through the Elide interface when necessary
+ *
+ * @author jrm
  */
 public class ElideConnector {
     private static final Logger LOG = LoggerFactory.getLogger(ElideConnector.class);

--- a/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/ExternalDoiService.java
+++ b/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/ExternalDoiService.java
@@ -41,6 +41,8 @@ public abstract class ExternalDoiService {
     private final Set<String> activeJobSet = new HashSet<>();
     private final Set<String> syncActiveJobSet = Collections.synchronizedSet(activeJobSet);
 
+    String MAILTO = "pass@jhu.edu";
+
     /**
      * The name of the external service
      * @return the name of the external service

--- a/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/ExternalDoiService.java
+++ b/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/ExternalDoiService.java
@@ -16,18 +16,104 @@
  */
 package org.eclipse.pass.doi.service;
 
+import static java.lang.Thread.sleep;
+
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import javax.json.JsonObject;
 
-public interface ExternalDoiService {
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-    public String name();
+public abstract class ExternalDoiService {
+    private static final Logger LOG = LoggerFactory.getLogger(ExternalDoiService.class);
+    private Set<String> activeJobs = new HashSet<>();
 
-    public String baseUrl();
+    public abstract String name();
 
-    public HashMap<String, String> parameterMap();
+    public  abstract String baseUrl();
 
-    public HashMap<String, String> headerMap();
+    public  abstract HashMap<String, String> parameterMap();
 
-    public JsonObject processObject(JsonObject object);
+    public  abstract HashMap<String, String> headerMap();
+
+    public  abstract JsonObject processObject(JsonObject object);
+
+    /**
+     * check to see whether supplied DOI is in valid format after splitting off a possible prefix
+     *
+     * @return the valid suffix, or null if invalid
+     */
+    String verify(String doi) {
+        LOG.debug("Verifying doi format for " + doi );
+        if (doi == null) {
+            return null;
+        }
+        String criterion = "doi.org/";
+        int i = doi.indexOf(criterion);
+        String suffix = i >= 0 ? doi.substring(i + criterion.length()) : doi;
+
+        Pattern pattern = Pattern.compile("^10\\.\\d{4,9}/[-._;()/:a-zA-Z0-9]+$");
+
+        Matcher matcher = pattern.matcher(suffix);
+        return matcher.matches() ? suffix : null;
+    }
+
+    /**
+     * this simply protects the external service from a person hammering on a request thinking
+     * it wasn't processed, when it really is just slow coming back
+     *
+     * @param doi the doi to check active
+     * @return whether the doi lookup is still active
+     */
+    boolean isAlreadyActive(String doi) {
+        //check cache map for existence of doi
+        //put doi on map if absent
+        LOG.debug("Checking to see if doi " + doi + " is already in process");
+        if (activeJobs.contains(doi)) {
+            return true;
+        } else {
+            // this DOI is not actively being processed
+            // let's temporarily prohibit new requests for this DOI
+            activeJobs.add(doi);
+            //longest time we expect it should take to create a Journal object, in
+            //milliseconds
+            int cachePeriod = 30000;
+            Thread t = new Thread(new ExternalDoiService.ExpiringLock(doi, cachePeriod));
+            t.start();
+        }
+        return false;
+    }
+
+    void unlockDoi(String doi) {
+        if (activeJobs.contains(doi)) {
+            activeJobs.remove(doi);
+        }
+    }
+
+    /**
+     * A class to manage locking so that an active process for a DOI will finish executing before
+     * another one begins
+     */
+    public class ExpiringLock implements Runnable {
+        private String key;
+        private int duration;
+
+        ExpiringLock(String key, int duration) {
+            this.key = key;
+            this.duration = duration;
+        }
+
+        public void run() {
+            try {
+                sleep(duration);
+                activeJobs.remove(key);
+            } catch (InterruptedException e) {
+                activeJobs.remove(key);
+            }
+        }
+    }
 }

--- a/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/ExternalDoiService.java
+++ b/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/ExternalDoiService.java
@@ -28,18 +28,44 @@ import javax.json.JsonObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * ExternalDoiService classes provide configuration needed for specific implementations'
+ * connections, as well as a method to process the raw JSON object returned by the external service to
+ * suit the requirements of the PASS UI.
+ */
 public abstract class ExternalDoiService {
     private static final Logger LOG = LoggerFactory.getLogger(ExternalDoiService.class);
-    private Set<String> activeJobs = new HashSet<>();
+    private final Set<String> activeJobs = new HashSet<>();
 
+    /**
+     * The name of the external service
+     * @return the name of the external service
+     */
     public abstract String name();
 
+    /**
+     * The base URL of the external service
+     * @return the base URL of the external service
+     */
     public  abstract String baseUrl();
 
+    /**
+     * A key, value map of query parameters used by the external service; null if there aren't any.
+     * @return the map
+     */
     public  abstract HashMap<String, String> parameterMap();
 
+    /**
+     * A key, value map of headers used by the external service; null if there aren't any.
+     * @return the map
+     */
     public  abstract HashMap<String, String> headerMap();
 
+    /**
+     * A method to transform the raw external service's JSON response to suit the UI requirements
+     * @param object the raw external JSON object
+     * @return the transformed JSON object
+     */
     public  abstract JsonObject processObject(JsonObject object);
 
     /**
@@ -88,10 +114,12 @@ public abstract class ExternalDoiService {
         return false;
     }
 
+    /**
+     * Once a doi has been processed, this method removes it from the locked list.
+     * @param doi the doi
+     */
     void unlockDoi(String doi) {
-        if (activeJobs.contains(doi)) {
-            activeJobs.remove(doi);
-        }
+        activeJobs.remove(doi);
     }
 
     /**
@@ -99,8 +127,8 @@ public abstract class ExternalDoiService {
      * another one begins
      */
     public class ExpiringLock implements Runnable {
-        private String key;
-        private int duration;
+        private final String key;
+        private final int duration;
 
         ExpiringLock(String key, int duration) {
             this.key = key;

--- a/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/ExternalDoiService.java
+++ b/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/ExternalDoiService.java
@@ -32,6 +32,8 @@ import org.slf4j.LoggerFactory;
  * ExternalDoiService classes provide configuration needed for specific implementations'
  * connections, as well as a method to process the raw JSON object returned by the external service to
  * suit the requirements of the PASS UI.
+ *
+ * @author jrm
  */
 public abstract class ExternalDoiService {
     private static final Logger LOG = LoggerFactory.getLogger(ExternalDoiService.class);

--- a/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/ExternalDoiService.java
+++ b/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/ExternalDoiService.java
@@ -1,0 +1,33 @@
+/*
+ *
+ * Copyright 2022 Johns Hopkins University
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.eclipse.pass.doi.service;
+
+import java.util.HashMap;
+import javax.json.JsonObject;
+
+public interface ExternalDoiService {
+
+    public String name();
+
+    public String baseUrl();
+
+    public HashMap<String, String> parameterMap();
+
+    public HashMap<String, String> headerMap();
+
+    public JsonObject processObject(JsonObject object);
+}

--- a/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/ExternalDoiServiceConnector.java
+++ b/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/ExternalDoiServiceConnector.java
@@ -100,7 +100,7 @@ public class ExternalDoiServiceConnector {
                            .build();
             }
         } catch (IOException e) {
-            return null;
+            LOG.error(e.getMessage(), e);
         }
         return null;
     }

--- a/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/ExternalDoiServiceConnector.java
+++ b/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/ExternalDoiServiceConnector.java
@@ -20,6 +20,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 import java.io.IOException;
 import java.io.StringReader;
+import java.util.Objects;
 import javax.json.Json;
 import javax.json.JsonObject;
 import javax.json.JsonReader;
@@ -34,10 +35,13 @@ import okhttp3.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * A class which manages the retrieval of JSON from external DOI services (Unpaywall, Crossref)
+ */
 public class ExternalDoiServiceConnector {
     private static final Logger LOG = LoggerFactory.getLogger(ExternalDoiServiceConnector.class);
 
-    private OkHttpClient client;
+    private final OkHttpClient client;
 
     ExternalDoiServiceConnector() {
         OkHttpClient.Builder builder = new OkHttpClient.Builder();
@@ -53,10 +57,10 @@ public class ExternalDoiServiceConnector {
      * @param doi - the supplied doi string, prefix trimmed if necessary
      * @return a string representing the works object if successful; an empty string if not found; null if IO exception
      */
-    JsonObject retrieveMetdata(String doi, ExternalDoiService service) {
+    JsonObject retrieveMetadata(String doi, ExternalDoiService service) {
         LOG.debug("Attempting to retrieve " + service.name() + "metadata for doi " + doi);
 
-        HttpUrl.Builder urlBuilder = HttpUrl.parse(service.baseUrl() + doi).newBuilder();
+        HttpUrl.Builder urlBuilder = Objects.requireNonNull(HttpUrl.parse(service.baseUrl() + doi)).newBuilder();
 
         if ( service.parameterMap() != null ) {
             for ( String key : service.parameterMap().keySet() ) {
@@ -79,7 +83,7 @@ public class ExternalDoiServiceConnector {
         String responseString = null;
 
         try (Response okHttpResponse = call.execute()) {
-            responseString = okHttpResponse.body().string();
+            responseString = Objects.requireNonNull(okHttpResponse.body()).string();
             reader = Json.createReader(new StringReader(responseString));
             metadataJsonObject = reader.readObject();
             reader.close();

--- a/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/ExternalDoiServiceConnector.java
+++ b/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/ExternalDoiServiceConnector.java
@@ -16,15 +16,10 @@
  */
 package org.eclipse.pass.doi.service;
 
-import static java.lang.Thread.sleep;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import java.io.IOException;
 import java.io.StringReader;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import javax.json.Json;
 import javax.json.JsonObject;
 import javax.json.JsonReader;
@@ -44,60 +39,12 @@ public class ExternalDoiServiceConnector {
 
     private OkHttpClient client;
 
-    private Set<String> activeJobs = new HashSet<>();
-
     ExternalDoiServiceConnector() {
         OkHttpClient.Builder builder = new OkHttpClient.Builder();
         builder.connectTimeout(30, SECONDS);
         builder.readTimeout(30, SECONDS);
         builder.writeTimeout(30, SECONDS);
         this.client = builder.build();
-    }
-
-    /**
-     * check to see whether supplied DOI is in valid format after splitting off a possible prefix
-     *
-     * @return the valid suffix, or null if invalid
-     */
-    String verify(String doi) {
-        LOG.debug("Verifying doi format for " + doi );
-        if (doi == null) {
-            return null;
-        }
-        String criterion = "doi.org/";
-        int i = doi.indexOf(criterion);
-        String suffix = i >= 0 ? doi.substring(i + criterion.length()) : doi;
-
-        Pattern pattern = Pattern.compile("^10\\.\\d{4,9}/[-._;()/:a-zA-Z0-9]+$");
-
-        Matcher matcher = pattern.matcher(suffix);
-        return matcher.matches() ? suffix : null;
-    }
-
-    /**
-     * this simply protects the crossref service from a person hammering on a request thinking
-     * it wasn't processed, when it really is just slow coming back
-     *
-     * @param doi the doi to check active
-     * @return whether the doi lookup is still active
-     */
-    boolean isAlreadyActive(String doi) {
-        //stage 2: check cache map for existence of doi
-        //put doi on map if absent
-        LOG.debug("Checking to see if doi " + doi + " is already in process");
-        if (activeJobs.contains(doi)) {
-            return true;
-        } else {
-            // this DOI is not actively being processed
-            // let's temporarily prohibit new requests for this DOI
-            activeJobs.add(doi);
-            //longest time we expect it should take to create a Journal object, in
-            //milliseconds
-            int cachePeriod = 30000;
-            Thread t = new Thread(new ExpiringLock(doi, cachePeriod));
-            t.start();
-        }
-        return false;
     }
 
     /**
@@ -112,8 +59,9 @@ public class ExternalDoiServiceConnector {
         HttpUrl.Builder urlBuilder = HttpUrl.parse(service.baseUrl() + doi).newBuilder();
 
         if ( service.parameterMap() != null ) {
-            for ( String key : service.parameterMap().keySet() )
-            urlBuilder.addQueryParameter(key, service.parameterMap().get(key));
+            for ( String key : service.parameterMap().keySet() ) {
+                urlBuilder.addQueryParameter(key, service.parameterMap().get(key));
+            }
         }
 
         String url = urlBuilder.build().toString();
@@ -136,7 +84,8 @@ public class ExternalDoiServiceConnector {
             metadataJsonObject = reader.readObject();
             reader.close();
 
-            activeJobs.remove(doi);
+            service.unlockDoi(doi);
+
             return metadataJsonObject;
         } catch (JsonParsingException e) {
             if (responseString != null) {
@@ -150,27 +99,5 @@ public class ExternalDoiServiceConnector {
         return null;
     }
 
-    /**
-     * A class to manage locking so that an active process for a DOI will finish executing before
-     * another one begins
-     */
-    public class ExpiringLock implements Runnable {
-        private String key;
-        private int duration;
-
-        ExpiringLock(String key, int duration) {
-            this.key = key;
-            this.duration = duration;
-        }
-
-        public void run() {
-            try {
-                sleep(duration);
-                activeJobs.remove(key);
-            } catch (InterruptedException e) {
-                activeJobs.remove(key);
-            }
-        }
-    }
 }
 

--- a/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/ExternalDoiServiceConnector.java
+++ b/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/ExternalDoiServiceConnector.java
@@ -37,6 +37,8 @@ import org.slf4j.LoggerFactory;
 
 /**
  * A class which manages the retrieval of JSON from external DOI services (Unpaywall, Crossref)
+ *
+ * @author jrm
  */
 public class ExternalDoiServiceConnector {
     private static final Logger LOG = LoggerFactory.getLogger(ExternalDoiServiceConnector.class);

--- a/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/PassDoiServiceController.java
+++ b/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/PassDoiServiceController.java
@@ -31,6 +31,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 /**
  * This class defines DOI service endpoints and orchestrates responses
+ *
+ * @author jrm
  */
 @RestController
 public class PassDoiServiceController {
@@ -48,7 +50,7 @@ public class PassDoiServiceController {
         this.unpaywallDoiService = new UnpaywallDoiService();
     }
 
-    @GetMapping("/journal")
+    @GetMapping("/doi/journal")
     protected void getXrefMetadata(HttpServletRequest request, HttpServletResponse response)
         throws IOException {
 
@@ -155,7 +157,7 @@ public class PassDoiServiceController {
         }
     }
 
-    @GetMapping("/manuscript")
+    @GetMapping("/doi/manuscript")
     protected void getUnpaywallMetadata(HttpServletRequest request, HttpServletResponse response)
         throws IOException {
 

--- a/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/UnpaywallDoiService.java
+++ b/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/UnpaywallDoiService.java
@@ -25,6 +25,8 @@ import javax.json.JsonValue;
 
 public class UnpaywallDoiService extends ExternalDoiService {
 
+    String UNPAYWALL_BASEURI = "https://api.unpaywall.org/v2/";
+
     @Override
     public String name() {
         return "Unpaywall";
@@ -32,7 +34,6 @@ public class UnpaywallDoiService extends ExternalDoiService {
 
     @Override
     public String baseUrl() {
-        String UNPAYWALL_BASEURI = "https://api.unpaywall.org/v2/";
         return System.getenv("UNPAYWALL_BASEURI") != null ? System.getenv(
             "UNPAYWALL_BASEURI") : UNPAYWALL_BASEURI;
     }
@@ -40,7 +41,6 @@ public class UnpaywallDoiService extends ExternalDoiService {
     @Override
     public HashMap<String, String> parameterMap() {
         HashMap<String, String> parameterMap = new HashMap<>();
-        String MAILTO = "pass@jhu.edu";
         String agent = System.getenv("PASS_DOI_SERVICE_MAILTO") != null ? System.getenv(
             "PASS_DOI_SERVICE_MAILTO") : MAILTO;
         parameterMap.put("email", agent);
@@ -60,6 +60,7 @@ public class UnpaywallDoiService extends ExternalDoiService {
         for (int i = 0; i < locations.size(); i++) {
             JsonObject manuscript = locations.getJsonObject(i);
             JsonValue urlForPdf = manuscript.getValue("/url_for_pdf");
+            JsonValue isBest = manuscript.getValue("/is_best");
 
             JsonValue filename;
             if ( urlForPdf == JsonValue.NULL ) {
@@ -76,6 +77,7 @@ public class UnpaywallDoiService extends ExternalDoiService {
                                               .add("type", "application/pdf")
                                               .add("source", name())
                                               .add("name", filename)
+                                              .add("isBest", isBest)
                                               .build();
             jab.add(manuscriptObject);
         }

--- a/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/UnpaywallDoiService.java
+++ b/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/UnpaywallDoiService.java
@@ -22,11 +22,11 @@ import javax.json.JsonArray;
 import javax.json.JsonArrayBuilder;
 import javax.json.JsonObject;
 
-public class UnpaywallDoiService implements ExternalDoiService {
+public class UnpaywallDoiService extends ExternalDoiService {
 
     //defaults
     private String MAILTO = "pass@jhu.edu";
-    String UNPAYWALL_BASEURI= "https://api.unpaywall.org/v2/";
+    String UNPAYWALL_BASEURI = "https://api.unpaywall.org/v2/";
 
     @Override
     public String name() {
@@ -43,7 +43,6 @@ public class UnpaywallDoiService implements ExternalDoiService {
     @Override
     public HashMap<String, String> parameterMap() {
         HashMap<String, String> parameterMap = new HashMap<>();
-
         String agent = System.getenv("PASS_DOI_SERVICE_MAILTO") != null ? System.getenv(
             "PASS_DOI_SERVICE_MAILTO") : MAILTO;
         parameterMap.put("email", agent);
@@ -55,26 +54,23 @@ public class UnpaywallDoiService implements ExternalDoiService {
         return null;
     }
 
-
     @Override
     public JsonObject processObject(JsonObject object) {
         JsonArray locations = object.getJsonArray("oa_locations");
-
         JsonArrayBuilder jab = Json.createArrayBuilder();
 
         for (int i = 0; i < locations.size(); i++) {
             JsonObject manuscript = locations.getJsonObject(i);
             String urlForPdf = manuscript.getString("url_for_pdf");
-            String filename = urlForPdf.substring(urlForPdf.lastIndexOf("/") + 1);
+            String filename = urlForPdf.substring(urlForPdf.lastIndexOf('/') + 1);
 
             JsonObject manuscriptObject = Json.createObjectBuilder().add("Location", urlForPdf)
                                               .add("RepositoryInstitution",
                                                    manuscript.getString("repository_institution"))
                                               .add("Type", "application/pdf")
-                                              .add("Source", "Unpaywall")
+                                              .add("Source", name())
                                               .add("Name", filename)
                                               .build();
-
             jab.add(manuscriptObject);
         }
 
@@ -82,5 +78,5 @@ public class UnpaywallDoiService implements ExternalDoiService {
                                     .add("Manuscripts", jab.build())
                                     .build();
         return jsonObject;
-        }
+    }
 }

--- a/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/UnpaywallDoiService.java
+++ b/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/UnpaywallDoiService.java
@@ -71,17 +71,17 @@ public class UnpaywallDoiService extends ExternalDoiService {
 
             JsonValue repoInst = manuscript.getValue("/repository_institution");
 
-            JsonObject manuscriptObject = Json.createObjectBuilder().add("Location", urlForPdf)
-                                              .add("RepositoryInstitution", repoInst)
-                                              .add("Type", "application/pdf")
-                                              .add("Source", name())
-                                              .add("Name", filename)
+            JsonObject manuscriptObject = Json.createObjectBuilder().add("url", urlForPdf)
+                                              .add("repositoryLabel", repoInst)
+                                              .add("type", "application/pdf")
+                                              .add("source", name())
+                                              .add("name", filename)
                                               .build();
             jab.add(manuscriptObject);
         }
 
         return Json.createObjectBuilder()
-                   .add("Manuscripts", jab.build())
+                   .add("manuscripts", jab.build())
                    .build();
     }
 }

--- a/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/UnpaywallDoiService.java
+++ b/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/UnpaywallDoiService.java
@@ -1,0 +1,86 @@
+/*
+ *
+ * Copyright 2022 Johns Hopkins University
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.eclipse.pass.doi.service;
+
+import java.util.HashMap;
+import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonArrayBuilder;
+import javax.json.JsonObject;
+
+public class UnpaywallDoiService implements ExternalDoiService {
+
+    //defaults
+    private String MAILTO = "pass@jhu.edu";
+    String UNPAYWALL_BASEURI= "https://api.unpaywall.org/v2/";
+
+    @Override
+    public String name() {
+        return "Unpaywall";
+    }
+
+    @Override
+    public String baseUrl() {
+        String baseUri = System.getenv("UNPAYWALL_BASEURI") != null ? System.getenv(
+            "UNPAYWALL_BASEURI") : UNPAYWALL_BASEURI;
+        return baseUri;
+    }
+
+    @Override
+    public HashMap<String, String> parameterMap() {
+        HashMap<String, String> parameterMap = new HashMap<>();
+
+        String agent = System.getenv("PASS_DOI_SERVICE_MAILTO") != null ? System.getenv(
+            "PASS_DOI_SERVICE_MAILTO") : MAILTO;
+        parameterMap.put("email", agent);
+        return parameterMap;
+    }
+
+    @Override
+    public HashMap<String, String> headerMap() {
+        return null;
+    }
+
+
+    @Override
+    public JsonObject processObject(JsonObject object) {
+        JsonArray locations = object.getJsonArray("oa_locations");
+
+        JsonArrayBuilder jab = Json.createArrayBuilder();
+
+        for (int i = 0; i < locations.size(); i++) {
+            JsonObject manuscript = locations.getJsonObject(i);
+            String urlForPdf = manuscript.getString("url_for_pdf");
+            String filename = urlForPdf.substring(urlForPdf.lastIndexOf("/") + 1);
+
+            JsonObject manuscriptObject = Json.createObjectBuilder().add("Location", urlForPdf)
+                                              .add("RepositoryInstitution",
+                                                   manuscript.getString("repository_institution"))
+                                              .add("Type", "application/pdf")
+                                              .add("Source", "Unpaywall")
+                                              .add("Name", filename)
+                                              .build();
+
+            jab.add(manuscriptObject);
+        }
+
+        JsonObject jsonObject = Json.createObjectBuilder()
+                                    .add("Manuscripts", jab.build())
+                                    .build();
+        return jsonObject;
+        }
+}

--- a/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/XrefDoiService.java
+++ b/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/XrefDoiService.java
@@ -1,0 +1,62 @@
+/*
+ *
+ * Copyright 2022 Johns Hopkins University
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.eclipse.pass.doi.service;
+
+import java.util.HashMap;
+import javax.json.JsonObject;
+
+public class XrefDoiService implements ExternalDoiService {
+
+    private String MAILTO = "pass@jhu.edu";
+    private String XREF_BASEURI = "https://api.crossref.org/v1/works/";
+
+
+    @Override
+    public String name() {
+        return "Crossref";
+    }
+
+    @Override
+    public String baseUrl() {
+        String baseUri = System.getenv("XREF_BASEURI") != null ? System.getenv(
+            "XREF_BASEURI") : XREF_BASEURI;
+        return baseUri;
+    }
+
+    @Override
+    public HashMap<String, String> parameterMap() {
+        return null;
+    }
+
+
+    @Override
+    public HashMap<String, String> headerMap() {
+        HashMap<String, String> headerMap = new HashMap<>();
+
+        String agent = System.getenv("PASS_DOI_SERVICE_MAILTO") != null ? System.getenv(
+            "PASS_DOI_SERVICE_MAILTO") : MAILTO;
+        headerMap.put("User-Agent", agent);
+        return headerMap;
+    }
+
+    @Override
+    public JsonObject processObject(JsonObject object) {
+        return object;
+    }
+
+
+}

--- a/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/XrefDoiService.java
+++ b/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/XrefDoiService.java
@@ -19,11 +19,10 @@ package org.eclipse.pass.doi.service;
 import java.util.HashMap;
 import javax.json.JsonObject;
 
-public class XrefDoiService implements ExternalDoiService {
+public class XrefDoiService extends ExternalDoiService {
 
     private String MAILTO = "pass@jhu.edu";
     private String XREF_BASEURI = "https://api.crossref.org/v1/works/";
-
 
     @Override
     public String name() {
@@ -42,11 +41,9 @@ public class XrefDoiService implements ExternalDoiService {
         return null;
     }
 
-
     @Override
     public HashMap<String, String> headerMap() {
         HashMap<String, String> headerMap = new HashMap<>();
-
         String agent = System.getenv("PASS_DOI_SERVICE_MAILTO") != null ? System.getenv(
             "PASS_DOI_SERVICE_MAILTO") : MAILTO;
         headerMap.put("User-Agent", agent);
@@ -57,6 +54,5 @@ public class XrefDoiService implements ExternalDoiService {
     public JsonObject processObject(JsonObject object) {
         return object;
     }
-
 
 }

--- a/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/XrefDoiService.java
+++ b/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/XrefDoiService.java
@@ -21,9 +21,6 @@ import javax.json.JsonObject;
 
 public class XrefDoiService extends ExternalDoiService {
 
-    private String MAILTO = "pass@jhu.edu";
-    private String XREF_BASEURI = "https://api.crossref.org/v1/works/";
-
     @Override
     public String name() {
         return "Crossref";
@@ -31,9 +28,9 @@ public class XrefDoiService extends ExternalDoiService {
 
     @Override
     public String baseUrl() {
-        String baseUri = System.getenv("XREF_BASEURI") != null ? System.getenv(
+        String XREF_BASEURI = "https://api.crossref.org/v1/works/";
+        return System.getenv("XREF_BASEURI") != null ? System.getenv(
             "XREF_BASEURI") : XREF_BASEURI;
-        return baseUri;
     }
 
     @Override
@@ -44,6 +41,7 @@ public class XrefDoiService extends ExternalDoiService {
     @Override
     public HashMap<String, String> headerMap() {
         HashMap<String, String> headerMap = new HashMap<>();
+        String MAILTO = "pass@jhu.edu";
         String agent = System.getenv("PASS_DOI_SERVICE_MAILTO") != null ? System.getenv(
             "PASS_DOI_SERVICE_MAILTO") : MAILTO;
         headerMap.put("User-Agent", agent);

--- a/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/XrefDoiService.java
+++ b/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/XrefDoiService.java
@@ -21,6 +21,8 @@ import javax.json.JsonObject;
 
 public class XrefDoiService extends ExternalDoiService {
 
+    String XREF_BASEURI = "https://api.crossref.org/v1/works/";
+
     @Override
     public String name() {
         return "Crossref";
@@ -28,7 +30,6 @@ public class XrefDoiService extends ExternalDoiService {
 
     @Override
     public String baseUrl() {
-        String XREF_BASEURI = "https://api.crossref.org/v1/works/";
         return System.getenv("XREF_BASEURI") != null ? System.getenv(
             "XREF_BASEURI") : XREF_BASEURI;
     }
@@ -41,7 +42,6 @@ public class XrefDoiService extends ExternalDoiService {
     @Override
     public HashMap<String, String> headerMap() {
         HashMap<String, String> headerMap = new HashMap<>();
-        String MAILTO = "pass@jhu.edu";
         String agent = System.getenv("PASS_DOI_SERVICE_MAILTO") != null ? System.getenv(
             "PASS_DOI_SERVICE_MAILTO") : MAILTO;
         headerMap.put("User-Agent", agent);

--- a/pass-core-doi-service/src/test/java/org/eclipse/pass/doi/service/ElideConnectorTest.java
+++ b/pass-core-doi-service/src/test/java/org/eclipse/pass/doi/service/ElideConnectorTest.java
@@ -32,6 +32,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * Unit tests for the elide connector
+ *
+ * @author jrm
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ElideConnectorTest {

--- a/pass-core-doi-service/src/test/java/org/eclipse/pass/doi/service/ElideConnectorTest.java
+++ b/pass-core-doi-service/src/test/java/org/eclipse/pass/doi/service/ElideConnectorTest.java
@@ -1,3 +1,19 @@
+/*
+ *
+ * Copyright 2022 Johns Hopkins University
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package org.eclipse.pass.doi.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/pass-core-doi-service/src/test/java/org/eclipse/pass/doi/service/ExternalDoiServiceConnectorTest.java
+++ b/pass-core-doi-service/src/test/java/org/eclipse/pass/doi/service/ExternalDoiServiceConnectorTest.java
@@ -25,7 +25,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 /**
- * Unit tests for the xref connector
+ * Unit tests for the connector
+ *
+ * @author jrm
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ExternalDoiServiceConnectorTest {

--- a/pass-core-doi-service/src/test/java/org/eclipse/pass/doi/service/ExternalDoiServiceConnectorTest.java
+++ b/pass-core-doi-service/src/test/java/org/eclipse/pass/doi/service/ExternalDoiServiceConnectorTest.java
@@ -18,8 +18,6 @@ package org.eclipse.pass.doi.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.StringReader;
 import javax.json.Json;
@@ -134,7 +132,8 @@ public class ExternalDoiServiceConnectorTest {
         "{\"updated\":\"2022-06-10T11:46:53.484862\",\"url\":\"https://europepmc.org/articles/pmc5072460?pdf=render\","  +
         "\"url_for_pdf\":\"https://europepmc.org/articles/pmc5072460?pdf=render\"," +
         "\"url_for_landing_page\":\"https://europepmc.org/articles/pmc5072460\"," +
-        "\"evidence\":\"oa repository (via OAI-PMH doi match)\",\"license\":\"implied-oa\",\"version\":\"publishedVersion\"," +
+        "\"evidence\":\"oa repository (via OAI-PMH doi match)\",\"license\":\"implied-oa\"," +
+        "\"version\":\"publishedVersion\"," +
         "\"host_type\":\"repository\",\"is_best\":false,\"pmh_id\":\"oai:europepmc.org:o4XNeKpNbeRdWobq6BX7\"," +
         "\"endpoint_id\":\"b5e840539009389b1a6\",\"repository_institution\":\"PubMed Central - Europe PMC\"," +
         "\"oa_date\":null},{\"updated\":\"2022-12-14T21:03:17.169410\"," +
@@ -166,6 +165,7 @@ public class ExternalDoiServiceConnectorTest {
         assertEquals(blob.getJsonObject("message").getJsonArray("ISSN"),
                      object.getJsonObject("message").getJsonArray("ISSN"));
     }
+
     /**
      * test that hitting the Crossref API with a doi returns the expected JSON object
      */
@@ -204,27 +204,5 @@ public class ExternalDoiServiceConnectorTest {
         assertEquals("true",blob.getValue("/error").toString());
     }
 
-
-
-    /**
-     * Test that our verify method correctly handles the usual expected doi formats
-     */
-    @Test
-    public void verifyTest() {
-        String doi0 = "http://dx.doi.org/10.4137/cmc.s38446";
-        assertEquals("10.4137/cmc.s38446", underTest.verify(doi0));
-
-        String doi1 = "https://dx.doi.org/10.4137/cmc.s38446";
-        assertEquals("10.4137/cmc.s38446", underTest.verify(doi1));
-
-        String doi2 = "dx.doi.org/10.4137/cmc.s38446";
-        assertEquals("10.4137/cmc.s38446", underTest.verify(doi2));
-
-        String doi3 = "10.4137/cmc.s38446";
-        assertEquals("10.4137/cmc.s38446", underTest.verify(doi3));
-
-        String doi4 = "4137/cmc.s38446";
-        assertNull(underTest.verify(doi4));
-    }
 }
 

--- a/pass-core-doi-service/src/test/java/org/eclipse/pass/doi/service/ExternalDoiServiceConnectorTest.java
+++ b/pass-core-doi-service/src/test/java/org/eclipse/pass/doi/service/ExternalDoiServiceConnectorTest.java
@@ -21,14 +21,18 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import javax.json.JsonObject;
 
+import jdk.nashorn.internal.ir.annotations.Ignore;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 /**
- * Unit tests for the connector
+ * Unit tests for the connector. This test class is @ignored in production, and is only used to
+ * verify behavior against live services when either the connector class or the external APIs
+ * are changed
  *
  * @author jrm
  */
+@Ignore
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ExternalDoiServiceConnectorTest {
 

--- a/pass-core-doi-service/src/test/java/org/eclipse/pass/doi/service/ExternalDoiServiceConnectorTest.java
+++ b/pass-core-doi-service/src/test/java/org/eclipse/pass/doi/service/ExternalDoiServiceConnectorTest.java
@@ -19,10 +19,7 @@ package org.eclipse.pass.doi.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import java.io.StringReader;
-import javax.json.Json;
 import javax.json.JsonObject;
-import javax.json.JsonReader;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -37,129 +34,15 @@ public class ExternalDoiServiceConnectorTest {
     private final ExternalDoiService xrefService = new XrefDoiService();
     private final ExternalDoiService unpaywallService = new UnpaywallDoiService();
 
-    //a real-life JSON metadata response for a DOI, from Crossref
-    private final String xrefJson = "{\"status\":\"ok\",\"message-type\":\"work\",\"message-version\":\"1.0.0\"," +
-                                    "\"message\":" +
-                                    "{\"indexed\":{\"date-parts\":[[2018,9,11]]," +
-                                    "\"date-time\":\"2018-09-11T22:02:39Z\"," +
-                                    "\"timestamp\":" +
-                                    "1536703359538},\"reference-count\":74,\"publisher\":\"SAGE Publications\"," +
-                                    "\"license\":[{\"URL\":" +
-                                    "\"http:\\/\\/journals.sagepub.com\\/page\\/policies\\/text-and-data-mining" +
-                                    "-license\"," +
-                                    "\"start\":" +
-                                    "{\"date-parts\":[[2016,1,1]],\"date-time\":\"2016-01-01T00:00:00Z\"," +
-                                    "\"timestamp\":" +
-                                    "1451606400000},\"delay-in-days\":0,\"content-version\":\"tdm\"}]," +
-                                    "\"content-domain\":{\"domain\":" +
-                                    "[\"journals.sagepub.com\"],\"crossmark-restriction\":true}," +
-                                    "\"short-container-title\":" +
-                                    "[\"Clinical Medicine Insights: Cardiology\"]," +
-                                    "\"published-print\":{\"date-parts\":" +
-                                    "[[2016,1]]},\"DOI\":\"10.4137\\/cmc.s38446\",\"type\":\"journal-article\"," +
-                                    "\"created\":" +
-                                    "{\"date-parts\":[[2016,10,19]],\"date-time\":\"2016-10-19T21:18:54Z\"," +
-                                    "\"timestamp\":" +
-                                    "1476911934000},\"page\":\"CMC.S38446\",\"update-policy\":" +
-                                    "\"http:\\/\\/dx.doi.org\\/10.1177\\/sage-journals-update-policy\",\"source\":" +
-                                    "\"Crossref\",\"is-referenced-by-count\":1,\"title\":" +
-                                    "[\"Arrhythmogenic Right Ventricular Dysplasia in Neuromuscular Disorders\"]," +
-                                    "\"prefix\":" +
-                                    "\"10.4137\",\"volume\":\"10\",\"author\":[{\"given\":\"Josef\"," +
-                                    "\"family\":\"Finsterer\",\"sequence\":" +
-                                    "\"first\",\"affiliation\":[{\"name\":\"Krankenanstalt Rudolfstiftung, Vienna, " +
-                                    "Austria" +
-                                    ".\"}]},{\"given\":" +
-                                    "\"Claudia\",\"family\":\"St\\u00f6llberger\",\"sequence\":\"additional\"," +
-                                    "\"affiliation\":[{\"name\":" +
-                                    "\"Krankenanstalt Rudolfstiftung, Vienna, Austria.\"}]}],\"member\":\"179\"," +
-                                    "\"published-online\":" +
-                                    "{\"date-parts\":[[2016,10,19]]},\"container-title\":[\"Clinical Medicine " +
-                                    "Insights: " +
-                                    "Cardiology\"],\"original-title\":" +
-                                    "[],\"language\":\"en\",\"link\":[{\"URL\":\"http:\\/\\/journals.sagepub" +
-                                    ".com\\/doi\\/pdf\\/10.4137\\/CMC.S38446\",\"content-type\":" +
-                                    "\"application\\/pdf\",\"content-version\":\"vor\"," +
-                                    "\"intended-application\":\"text-mining\"},{\"URL\":" +
-                                    "\"http:\\/\\/journals.sagepub.com\\/doi\\/full-xml\\/10.4137\\/CMC.S38446\"," +
-                                    "\"content-type\":\"application\\/xml\",\"content-version\":" +
-                                    "\"vor\",\"intended-application\":\"text-mining\"},{\"URL\":" +
-                                    "\"http:\\/\\/journals.sagepub.com\\/doi\\/pdf\\/10.4137\\/CMC.S38446\"," +
-                                    "\"content-type\":\"unspecified\",\"content-version\":" +
-                                    "\"vor\",\"intended-application\":\"similarity-checking\"}]," +
-                                    "\"deposited\":{\"date-parts\":[[2017,12,13]],\"date-time\":" +
-                                    "\"2017-12-13T00:51:44Z\",\"timestamp\":1513126304000},\"score\":1.0," +
-                                    "\"subtitle\":[]," +
-                                    "\"short-title\":[],\"issued\":" +
-                                    "{\"date-parts\":[[2016,1]]},\"references-count\":74,\"alternative-id\":[\"10" +
-                                    ".4137\\/CMC.S38446\"],\"URL\":" +
-                                    "\"http:\\/\\/dx.doi.org\\/10.4137\\/cmc.s38446\",\"relation\":{}," +
-                                    "\"ISSN\":[\"1179-5468\",\"1179-5468\"],\"issn-type\":[{\"value\":" +
-                                    "\"1179-5468\",\"type\":\"print\"},{\"value\":\"1179-5468\"," +
-                                    "\"type\":\"electronic\"}]}}";
-
-    //a real life JSON metadata response for a DOI, from unpaywall
-    private final String unpaywallJson =
-        "{\"doi\":\"10.4137/cmc.s38446\"," +
-        "\"doi_url\":\"https://doi.org/10.4137/cmc.s38446\"," +
-        "\"title\":\"Arrhythmogenic Right Ventricular Dysplasia in Neuromuscular Disorders\"," +
-        "\"genre\":\"journal-article\",\"is_paratext\":false," +
-        "\"published_date\":\"2016-01-01\",\"year\":2016," +
-        "\"journal_name\":\"Clinical Medicine Insights: Cardiology\",\"journal_issns\":\"1179-5468,1179-5468\"," +
-        "\"journal_issn_l\":\"1179-5468\",\"journal_is_oa\":true,\"journal_is_in_doaj\":true," +
-        "\"publisher\":\"SAGE Publications\",\"is_oa\":true,\"oa_status\":\"gold\",\"has_repository_copy\":true," +
-        "\"best_oa_location\":{\"updated\":\"2022-12-14T21:03:17.169317\"," +
-        "\"url\":\"https://journals.sagepub.com/doi/pdf/10.4137/CMC.S38446\"," +
-        "\"url_for_pdf\":\"https://journals.sagepub.com/doi/pdf/10.4137/CMC.S38446\"," +
-        "\"url_for_landing_page\":\"https://doi.org/10.4137/cmc.s38446\"," +
-        "\"evidence\":\"oa journal (via doaj)\",\"license\":\"cc-by-nc\",\"version\":\"publishedVersion\"," +
-        "\"host_type\":\"publisher\",\"is_best\":true,\"pmh_id\":null,\"endpoint_id\":null," +
-        "\"repository_institution\":null,\"oa_date\":\"2016-01-01\"}," +
-        "\"first_oa_location\":{\"updated\":\"2022-12-14T21:03:17.169317\"," +
-        "\"url\":\"https://journals.sagepub.com/doi/pdf/10.4137/CMC.S38446\"," +
-        "\"url_for_pdf\":\"https://journals.sagepub.com/doi/pdf/10.4137/CMC.S38446\"," +
-        "\"url_for_landing_page\":\"https://doi.org/10.4137/cmc.s38446\"," +
-        "\"evidence\":\"oa journal (via doaj)\",\"license\":\"cc-by-nc\",\"version\":\"publishedVersion\"," +
-        "\"host_type\":\"publisher\",\"is_best\":true,\"pmh_id\":null,\"endpoint_id\":null," +
-        "\"repository_institution\":null,\"oa_date\":\"2016-01-01\"}," +
-        "\"oa_locations\":[{\"updated\":\"2022-12-14T21:03:17.169317\"," +
-        "\"url\":\"https://journals.sagepub.com/doi/pdf/10.4137/CMC.S38446\"," +
-        "\"url_for_pdf\":\"https://journals.sagepub.com/doi/pdf/10.4137/CMC.S38446\"," +
-        "\"url_for_landing_page\":\"https://doi.org/10.4137/cmc.s38446\"," +
-        "\"evidence\":\"oa journal (via doaj)\",\"license\":\"cc-by-nc\",\"version\":\"publishedVersion\"," +
-        "\"host_type\":\"publisher\",\"is_best\":true,\"pmh_id\":null,\"endpoint_id\":null," +
-        "\"repository_institution\":null,\"oa_date\":\"2016-01-01\"}," +
-        "{\"updated\":\"2022-06-10T11:46:53.484862\",\"url\":\"https://europepmc.org/articles/pmc5072460?pdf=render\","  +
-        "\"url_for_pdf\":\"https://europepmc.org/articles/pmc5072460?pdf=render\"," +
-        "\"url_for_landing_page\":\"https://europepmc.org/articles/pmc5072460\"," +
-        "\"evidence\":\"oa repository (via OAI-PMH doi match)\",\"license\":\"implied-oa\"," +
-        "\"version\":\"publishedVersion\"," +
-        "\"host_type\":\"repository\",\"is_best\":false,\"pmh_id\":\"oai:europepmc.org:o4XNeKpNbeRdWobq6BX7\"," +
-        "\"endpoint_id\":\"b5e840539009389b1a6\",\"repository_institution\":\"PubMed Central - Europe PMC\"," +
-        "\"oa_date\":null},{\"updated\":\"2022-12-14T21:03:17.169410\"," +
-        "\"url\":\"https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5072460\",\"url_for_pdf\":null," +
-        "\"url_for_landing_page\":\"https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5072460\"," +
-        "\"evidence\":\"oa repository (via pmcid lookup)\",\"license\":null,\"version\":\"publishedVersion\"," +
-        "\"host_type\":\"repository\",\"is_best\":false,\"pmh_id\":null,\"endpoint_id\":null," +
-        "\"repository_institution\":null,\"oa_date\":null}],\"oa_locations_embargoed\":[]," +
-        "\"updated\":\"2021-11-28T21:57:53.965749\",\"data_standard\":2,\"z_authors\":[{\"given\":\"Josef\"," +
-        "\"family\":\"Finsterer\",\"sequence\":\"first\",\"affiliation\":" +
-        "[{\"name\":\"Krankenanstalt Rudolfstiftung, Vienna, Austria.\"}]}," +
-        "{\"given\":\"Claudia\",\"family\":\"Stöllberger\",\"sequence\":\"additional\"," +
-        "\"affiliation\":[{\"name\":\"Krankenanstalt Rudolfstiftung, Vienna, Austria.\"}]}]}";
-
-
     /**
      * test that hitting the Crossref API with a doi returns the expected JSON object
      */
     @Test
     public void testXrefLookup() {
         String realDoi = "10.4137/cmc.s38446";
-        JsonObject blob = underTest.retrieveMetdata(realDoi, xrefService);
+        JsonObject blob = underTest.retrieveMetadata(realDoi, xrefService);
         //these results will differ by a timestamp - but a good check is that they return the same journal objects
-        JsonReader reader = Json.createReader(new StringReader(xrefJson));
-        JsonObject object = reader.readObject();
-        reader.close();
+        JsonObject object = JsonTestObjects.xrefTestJsonObject();
 
         assertNotNull(blob.getJsonObject("message").getJsonArray("ISSN"));
         assertEquals(blob.getJsonObject("message").getJsonArray("ISSN"),
@@ -167,21 +50,18 @@ public class ExternalDoiServiceConnectorTest {
     }
 
     /**
-     * test that hitting the Crossref API with a doi returns the expected JSON object
+     * test that hitting the Unpaywall API with a doi returns the expected JSON object
      */
     @Test
     public void testUnpaywallLookup() {
         String realDoi = "10.4137/cmc.s38446"; //"10.1038/nature12373";
-        JsonObject blob = underTest.retrieveMetdata(realDoi, unpaywallService);
+        JsonObject blob = underTest.retrieveMetadata(realDoi, unpaywallService);
 
-        JsonReader reader = Json.createReader(new StringReader(unpaywallJson));
-        JsonObject object = reader.readObject();
-        reader.close();
+        JsonObject object = JsonTestObjects.unpaywallTestJsonObject();
 
         assertNotNull(blob.getJsonString("doi"));
         assertEquals(blob.getJsonString("doi"), object.getJsonString("doi"));
 
-        System.err.println(object.getJsonArray("oa_locations").getJsonObject(0).getString("url_for_pdf"));
     }
 
     /**
@@ -190,7 +70,7 @@ public class ExternalDoiServiceConnectorTest {
     @Test
     public void testBadXrefDoiLookup() {
         String badDoi = "10.1212/abc.DEF";
-        JsonObject blob = underTest.retrieveMetdata(badDoi, xrefService);
+        JsonObject blob = underTest.retrieveMetadata(badDoi, xrefService);
         assertEquals("Resource not found.", blob.getString("error"));
     }
 
@@ -200,8 +80,9 @@ public class ExternalDoiServiceConnectorTest {
     @Test
     public void testBadUnpaywallDoiLookup() {
         String badDoi = "10.1212/abc.DEF";
-        JsonObject blob = underTest.retrieveMetdata(badDoi, unpaywallService);
+        JsonObject blob = underTest.retrieveMetadata(badDoi, unpaywallService);
         assertEquals("true",blob.getValue("/error").toString());
+        assertEquals("404", blob.getValue("/HTTP_status_code").toString());
     }
 
 }

--- a/pass-core-doi-service/src/test/java/org/eclipse/pass/doi/service/ExternalDoiServiceTest.java
+++ b/pass-core-doi-service/src/test/java/org/eclipse/pass/doi/service/ExternalDoiServiceTest.java
@@ -1,0 +1,34 @@
+package org.eclipse.pass.doi.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class ExternalDoiServiceTest {
+
+    ExternalDoiService underTest = new XrefDoiService();
+
+    /**
+     * Test that our verify method correctly handles the usual expected doi formats
+     */
+    @Test
+    public void verifyTest() {
+        String doi0 = "http://dx.doi.org/10.4137/cmc.s38446";
+        assertEquals("10.4137/cmc.s38446", underTest.verify(doi0));
+
+        String doi1 = "https://dx.doi.org/10.4137/cmc.s38446";
+        assertEquals("10.4137/cmc.s38446", underTest.verify(doi1));
+
+        String doi2 = "dx.doi.org/10.4137/cmc.s38446";
+        assertEquals("10.4137/cmc.s38446", underTest.verify(doi2));
+
+        String doi3 = "10.4137/cmc.s38446";
+        assertEquals("10.4137/cmc.s38446", underTest.verify(doi3));
+
+        String doi4 = "4137/cmc.s38446";
+        assertNull(underTest.verify(doi4));
+    }
+}

--- a/pass-core-doi-service/src/test/java/org/eclipse/pass/doi/service/ExternalDoiServiceTest.java
+++ b/pass-core-doi-service/src/test/java/org/eclipse/pass/doi/service/ExternalDoiServiceTest.java
@@ -1,3 +1,19 @@
+/*
+ *
+ * Copyright 2022 Johns Hopkins University
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
 package org.eclipse.pass.doi.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/pass-core-doi-service/src/test/java/org/eclipse/pass/doi/service/JsonTestObjects.java
+++ b/pass-core-doi-service/src/test/java/org/eclipse/pass/doi/service/JsonTestObjects.java
@@ -1,0 +1,158 @@
+/*
+ *
+ * Copyright 2022 Johns Hopkins University
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.eclipse.pass.doi.service;
+
+import java.io.StringReader;
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+
+/**
+ * A utility class to provide real-life json responses
+ */
+public class JsonTestObjects {
+
+    private JsonTestObjects() {
+        //empty constructor
+    }
+
+    //a real-life JSON metadata response for a DOI, from Crossref
+    private static final String xrefJson = "{\"status\":\"ok\",\"message-type\":\"work\"," +
+                                    "\"message-version\":\"1.0.0\",\"message\":" +
+                                    "{\"indexed\":{\"date-parts\":[[2018,9,11]]," +
+                                    "\"date-time\":\"2018-09-11T22:02:39Z\"," +
+                                    "\"timestamp\":" +
+                                    "1536703359538},\"reference-count\":74,\"publisher\":\"SAGE Publications\"," +
+                                    "\"license\":[{\"URL\":" +
+                                    "\"http:\\/\\/journals.sagepub.com\\/page\\/policies\\/text-and-data-mining" +
+                                    "-license\"," +
+                                    "\"start\":" +
+                                    "{\"date-parts\":[[2016,1,1]],\"date-time\":\"2016-01-01T00:00:00Z\"," +
+                                    "\"timestamp\":" +
+                                    "1451606400000},\"delay-in-days\":0,\"content-version\":\"tdm\"}]," +
+                                    "\"content-domain\":{\"domain\":" +
+                                    "[\"journals.sagepub.com\"],\"crossmark-restriction\":true}," +
+                                    "\"short-container-title\":" +
+                                    "[\"Clinical Medicine Insights: Cardiology\"]," +
+                                    "\"published-print\":{\"date-parts\":" +
+                                    "[[2016,1]]},\"DOI\":\"10.4137\\/cmc.s38446\",\"type\":\"journal-article\"," +
+                                    "\"created\":" +
+                                    "{\"date-parts\":[[2016,10,19]],\"date-time\":\"2016-10-19T21:18:54Z\"," +
+                                    "\"timestamp\":" +
+                                    "1476911934000},\"page\":\"CMC.S38446\",\"update-policy\":" +
+                                    "\"http:\\/\\/dx.doi.org\\/10.1177\\/sage-journals-update-policy\",\"source\":" +
+                                    "\"Crossref\",\"is-referenced-by-count\":1,\"title\":" +
+                                    "[\"Arrhythmogenic Right Ventricular Dysplasia in Neuromuscular Disorders\"]," +
+                                    "\"prefix\":" +
+                                    "\"10.4137\",\"volume\":\"10\",\"author\":[{\"given\":\"Josef\"," +
+                                    "\"family\":\"Finsterer\",\"sequence\":" +
+                                    "\"first\",\"affiliation\":[{\"name\":\"Krankenanstalt Rudolfstiftung, Vienna, " +
+                                    "Austria" +
+                                    ".\"}]},{\"given\":" +
+                                    "\"Claudia\",\"family\":\"St\\u00f6llberger\",\"sequence\":\"additional\"," +
+                                    "\"affiliation\":[{\"name\":" +
+                                    "\"Krankenanstalt Rudolfstiftung, Vienna, Austria.\"}]}],\"member\":\"179\"," +
+                                    "\"published-online\":" +
+                                    "{\"date-parts\":[[2016,10,19]]},\"container-title\":[\"Clinical Medicine " +
+                                    "Insights: " +
+                                    "Cardiology\"],\"original-title\":" +
+                                    "[],\"language\":\"en\",\"link\":[{\"URL\":\"http:\\/\\/journals.sagepub" +
+                                    ".com\\/doi\\/pdf\\/10.4137\\/CMC.S38446\",\"content-type\":" +
+                                    "\"application\\/pdf\",\"content-version\":\"vor\"," +
+                                    "\"intended-application\":\"text-mining\"},{\"URL\":" +
+                                    "\"http:\\/\\/journals.sagepub.com\\/doi\\/full-xml\\/10.4137\\/CMC.S38446\"," +
+                                    "\"content-type\":\"application\\/xml\",\"content-version\":" +
+                                    "\"vor\",\"intended-application\":\"text-mining\"},{\"URL\":" +
+                                    "\"http:\\/\\/journals.sagepub.com\\/doi\\/pdf\\/10.4137\\/CMC.S38446\"," +
+                                    "\"content-type\":\"unspecified\",\"content-version\":" +
+                                    "\"vor\",\"intended-application\":\"similarity-checking\"}]," +
+                                    "\"deposited\":{\"date-parts\":[[2017,12,13]],\"date-time\":" +
+                                    "\"2017-12-13T00:51:44Z\",\"timestamp\":1513126304000},\"score\":1.0," +
+                                    "\"subtitle\":[]," +
+                                    "\"short-title\":[],\"issued\":" +
+                                    "{\"date-parts\":[[2016,1]]},\"references-count\":74,\"alternative-id\":[\"10" +
+                                    ".4137\\/CMC.S38446\"],\"URL\":" +
+                                    "\"http:\\/\\/dx.doi.org\\/10.4137\\/cmc.s38446\",\"relation\":{}," +
+                                    "\"ISSN\":[\"1179-5468\",\"1179-5468\"],\"issn-type\":[{\"value\":" +
+                                    "\"1179-5468\",\"type\":\"print\"},{\"value\":\"1179-5468\"," +
+                                    "\"type\":\"electronic\"}]}}";
+
+    //a real life JSON metadata response for a DOI, from unpaywall
+    private static final String unpaywallJson =
+        "{\"doi\":\"10.4137/cmc.s38446\"," +
+        "\"doi_url\":\"https://doi.org/10.4137/cmc.s38446\"," +
+        "\"title\":\"Arrhythmogenic Right Ventricular Dysplasia in Neuromuscular Disorders\"," +
+        "\"genre\":\"journal-article\",\"is_paratext\":false," +
+        "\"published_date\":\"2016-01-01\",\"year\":2016," +
+        "\"journal_name\":\"Clinical Medicine Insights: Cardiology\",\"journal_issns\":\"1179-5468,1179-5468\"," +
+        "\"journal_issn_l\":\"1179-5468\",\"journal_is_oa\":true,\"journal_is_in_doaj\":true," +
+        "\"publisher\":\"SAGE Publications\",\"is_oa\":true,\"oa_status\":\"gold\",\"has_repository_copy\":true," +
+        "\"best_oa_location\":{\"updated\":\"2022-12-14T21:03:17.169317\"," +
+        "\"url\":\"https:\\/\\/journals.sagepub.com/doi/pdf/10.4137/CMC.S38446\"," +
+        "\"url_for_pdf\":\"https:\\/\\/journals.sagepub.com\\/doi\\/pdf\\/10.4137\\/CMC.S38446\"," +
+        "\"url_for_landing_page\":\"https:\\/\\/doi.org\\/10.4137\\/cmc.s38446\"," +
+        "\"evidence\":\"oa journal (via doaj)\",\"license\":\"cc-by-nc\",\"version\":\"publishedVersion\"," +
+        "\"host_type\":\"publisher\",\"is_best\":true,\"pmh_id\":null,\"endpoint_id\":null," +
+        "\"repository_institution\":null,\"oa_date\":\"2016-01-01\"}," +
+        "\"first_oa_location\":{\"updated\":\"2022-12-14T21:03:17.169317\"," +
+        "\"url\":\"https:\\/\\/journals.sagepub.com\\/doi\\/pdf\\/10.4137\\/CMC.S38446\"," +
+        "\"url_for_pdf\":\"https:\\/\\/journals.sagepub.com\\/doi\\/pdf\\/10.4137\\/CMC.S38446\"," +
+        "\"url_for_landing_page\":\"https:\\/\\/doi.org\\/10.4137\\/cmc.s38446\"," +
+        "\"evidence\":\"oa journal (via doaj)\",\"license\":\"cc-by-nc\",\"version\":\"publishedVersion\"," +
+        "\"host_type\":\"publisher\",\"is_best\":true,\"pmh_id\":null,\"endpoint_id\":null," +
+        "\"repository_institution\":null,\"oa_date\":\"2016-01-01\"}," +
+        "\"oa_locations\":[{\"updated\":\"2022-12-14T21:03:17.169317\"," +
+        "\"url\":\"https:\\/\\/journals.sagepub.com\\/doi\\/pdf\\/10.4137\\/CMC.S38446\"," +
+        "\"url_for_pdf\":\"https:\\/\\/journals.sagepub.com\\/doi\\/pdf\\/10.4137\\/CMC.S38446\"," +
+        "\"url_for_landing_page\":\"https:\\/\\/doi.org\\/10.4137\\/cmc.s38446\"," +
+        "\"evidence\":\"oa journal (via doaj)\",\"license\":\"cc-by-nc\",\"version\":\"publishedVersion\"," +
+        "\"host_type\":\"publisher\",\"is_best\":true,\"pmh_id\":null,\"endpoint_id\":null," +
+        "\"repository_institution\":null,\"oa_date\":\"2016-01-01\"}," +
+        "{\"updated\":\"2022-06-10T11:46:53.484862\"," +
+        "\"url\":\"https:\\/\\/europepmc.org\\/articles\\/pmc5072460?pdf=render\","  +
+        "\"url_for_pdf\":\"https:\\/\\/europepmc.org\\/articles\\/pmc5072460?pdf=render\"," +
+        "\"url_for_landing_page\":\"https:\\/\\/europepmc.org\\/articles\\/pmc5072460\"," +
+        "\"evidence\":\"oa repository (via OAI-PMH doi match)\",\"license\":\"implied-oa\"," +
+        "\"version\":\"publishedVersion\"," +
+        "\"host_type\":\"repository\",\"is_best\":false,\"pmh_id\":\"oai:europepmc.org:o4XNeKpNbeRdWobq6BX7\"," +
+        "\"endpoint_id\":\"b5e840539009389b1a6\",\"repository_institution\":\"PubMed Central - Europe PMC\"," +
+        "\"oa_date\":null},{\"updated\":\"2022-12-14T21:03:17.169410\"," +
+        "\"url\":\"https:\\/\\/www.ncbi.nlm.nih.gov\\/pmc\\/articles\\/PMC5072460\",\"url_for_pdf\":null," +
+        "\"url_for_landing_page\":\"https:\\/\\/www.ncbi.nlm.nih.gov\\/pmc\\/articles\\/PMC5072460\"," +
+        "\"evidence\":\"oa repository (via pmcid lookup)\",\"license\":null,\"version\":\"publishedVersion\"," +
+        "\"host_type\":\"repository\",\"is_best\":false,\"pmh_id\":null,\"endpoint_id\":null," +
+        "\"repository_institution\":null,\"oa_date\":null}],\"oa_locations_embargoed\":[]," +
+        "\"updated\":\"2021-11-28T21:57:53.965749\",\"data_standard\":2,\"z_authors\":[{\"given\":\"Josef\"," +
+        "\"family\":\"Finsterer\",\"sequence\":\"first\",\"affiliation\":" +
+        "[{\"name\":\"Krankenanstalt Rudolfstiftung, Vienna, Austria.\"}]}," +
+        "{\"given\":\"Claudia\",\"family\":\"Stöllberger\",\"sequence\":\"additional\"," +
+        "\"affiliation\":[{\"name\":\"Krankenanstalt Rudolfstiftung, Vienna, Austria.\"}]}]}";
+
+    static JsonObject xrefTestJsonObject() {
+        JsonReader reader = Json.createReader(new StringReader(xrefJson));
+        JsonObject object = reader.readObject();
+        reader.close();
+        return object;
+    }
+
+    static JsonObject unpaywallTestJsonObject() {
+        JsonReader reader = Json.createReader(new StringReader(unpaywallJson));
+        JsonObject object = reader.readObject();
+        reader.close();
+        return object;
+    }
+}

--- a/pass-core-doi-service/src/test/java/org/eclipse/pass/doi/service/JsonTestObjects.java
+++ b/pass-core-doi-service/src/test/java/org/eclipse/pass/doi/service/JsonTestObjects.java
@@ -23,6 +23,8 @@ import javax.json.JsonReader;
 
 /**
  * A utility class to provide real-life json responses
+ *
+ * @author jrm
  */
 public class JsonTestObjects {
 

--- a/pass-core-doi-service/src/test/java/org/eclipse/pass/doi/service/UnpaywallDoiServiceTest.java
+++ b/pass-core-doi-service/src/test/java/org/eclipse/pass/doi/service/UnpaywallDoiServiceTest.java
@@ -27,13 +27,13 @@ public class UnpaywallDoiServiceTest {
     ExternalDoiService underTest = new UnpaywallDoiService();
 
     String unpaywallData =
-        "{\"Manuscripts\":[{\"Location\":\"https://journals.sagepub.com/doi/pdf/10.4137/CMC.S38446\"," +
-        "\"RepositoryInstitution\":null,\"Type\":\"application/pdf\",\"Source\":\"Unpaywall\"," +
-        "\"Name\":\"CMC.S38446\"},{\"Location\":\"https://europepmc.org/articles/pmc5072460?pdf=render\"," +
-        "\"RepositoryInstitution\":\"PubMed Central - Europe PMC\",\"Type\":\"application/pdf\"," +
-        "\"Source\":\"Unpaywall\",\"Name\":\"pmc5072460?pdf=render\"}," +
-        "{\"Location\":null,\"RepositoryInstitution\":null,\"Type\":\"application/pdf\"," +
-        "\"Source\":\"Unpaywall\",\"Name\":null}]}";
+        "{\"manuscripts\":[{\"url\":\"https://journals.sagepub.com/doi/pdf/10.4137/CMC.S38446\"," +
+        "\"repositoryLabel\":null,\"type\":\"application/pdf\",\"source\":\"Unpaywall\"," +
+        "\"name\":\"CMC.S38446\"},{\"url\":\"https://europepmc.org/articles/pmc5072460?pdf=render\"," +
+        "\"repositoryLabel\":\"PubMed Central - Europe PMC\",\"type\":\"application/pdf\"," +
+        "\"source\":\"Unpaywall\",\"name\":\"pmc5072460?pdf=render\"}," +
+        "{\"url\":null,\"repositoryLabel\":null,\"type\":\"application/pdf\"," +
+        "\"source\":\"Unpaywall\",\"name\":null}]}";
 
     @Test
     public void testProcessObject() {

--- a/pass-core-doi-service/src/test/java/org/eclipse/pass/doi/service/UnpaywallDoiServiceTest.java
+++ b/pass-core-doi-service/src/test/java/org/eclipse/pass/doi/service/UnpaywallDoiServiceTest.java
@@ -1,0 +1,45 @@
+/*
+ *
+ * Copyright 2022 Johns Hopkins University
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.eclipse.pass.doi.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class UnpaywallDoiServiceTest {
+
+    ExternalDoiService underTest = new UnpaywallDoiService();
+
+    String unpaywallData =
+        "{\"Manuscripts\":[{\"Location\":\"https://journals.sagepub.com/doi/pdf/10.4137/CMC.S38446\"," +
+        "\"RepositoryInstitution\":null,\"Type\":\"application/pdf\",\"Source\":\"Unpaywall\"," +
+        "\"Name\":\"CMC.S38446\"},{\"Location\":\"https://europepmc.org/articles/pmc5072460?pdf=render\"," +
+        "\"RepositoryInstitution\":\"PubMed Central - Europe PMC\",\"Type\":\"application/pdf\"," +
+        "\"Source\":\"Unpaywall\",\"Name\":\"pmc5072460?pdf=render\"}," +
+        "{\"Location\":null,\"RepositoryInstitution\":null,\"Type\":\"application/pdf\"," +
+        "\"Source\":\"Unpaywall\",\"Name\":null}]}";
+
+    @Test
+    public void testProcessObject() {
+
+        assertEquals(unpaywallData,
+            underTest.processObject(JsonTestObjects.unpaywallTestJsonObject()).toString());
+    }
+
+}

--- a/pass-core-doi-service/src/test/java/org/eclipse/pass/doi/service/UnpaywallDoiServiceTest.java
+++ b/pass-core-doi-service/src/test/java/org/eclipse/pass/doi/service/UnpaywallDoiServiceTest.java
@@ -29,11 +29,11 @@ public class UnpaywallDoiServiceTest {
     String unpaywallData =
         "{\"manuscripts\":[{\"url\":\"https://journals.sagepub.com/doi/pdf/10.4137/CMC.S38446\"," +
         "\"repositoryLabel\":null,\"type\":\"application/pdf\",\"source\":\"Unpaywall\"," +
-        "\"name\":\"CMC.S38446\"},{\"url\":\"https://europepmc.org/articles/pmc5072460?pdf=render\"," +
+        "\"name\":\"CMC.S38446\",\"isBest\":true},{\"url\":\"https://europepmc.org/articles/pmc5072460?pdf=render\"," +
         "\"repositoryLabel\":\"PubMed Central - Europe PMC\",\"type\":\"application/pdf\"," +
-        "\"source\":\"Unpaywall\",\"name\":\"pmc5072460?pdf=render\"}," +
+        "\"source\":\"Unpaywall\",\"name\":\"pmc5072460?pdf=render\",\"isBest\":false}," +
         "{\"url\":null,\"repositoryLabel\":null,\"type\":\"application/pdf\"," +
-        "\"source\":\"Unpaywall\",\"name\":null}]}";
+        "\"source\":\"Unpaywall\",\"name\":null,\"isBest\":false}]}";
 
     @Test
     public void testProcessObject() {

--- a/pass-core-main/src/test/java/org/eclipse/pass/doi/service/DoiServiceTest.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/doi/service/DoiServiceTest.java
@@ -53,7 +53,7 @@ public class DoiServiceTest extends IntegrationTest {
         Call call = httpClient.newCall(okHttpRequest);
         try (Response okHttpResponse = call.execute()) {
             assertEquals(400, okHttpResponse.code());
-            assertEquals("{\"error\":\"Supplied DOI is not in valid Crossref format.\"}",
+            assertEquals("{\"error\":\"Supplied DOI is not in valid DOI format.\"}",
                          okHttpResponse.body().string());
 
         }
@@ -75,7 +75,7 @@ public class DoiServiceTest extends IntegrationTest {
         Call call = httpClient.newCall(okHttpRequest);
         try (Response okHttpResponse = call.execute()) {
             assertEquals(400, okHttpResponse.code());
-            assertEquals("{\"error\":\"Supplied DOI is not in valid Crossref format.\"}",
+            assertEquals("{\"error\":\"Supplied DOI is not in valid DOI format.\"}",
                          okHttpResponse.body().string());
 
         }

--- a/pass-core-main/src/test/java/org/eclipse/pass/doi/service/DoiServiceTest.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/doi/service/DoiServiceTest.java
@@ -208,6 +208,7 @@ public class DoiServiceTest extends IntegrationTest {
             .scheme("http")
             .host("localhost")
             .port(port)
+            .addPathSegment("doi")
             .addPathSegment("journal")
             .addQueryParameter("doi", doi)
             .build();

--- a/pass-core-main/src/test/java/org/eclipse/pass/doi/service/DoiServiceTest.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/doi/service/DoiServiceTest.java
@@ -192,7 +192,6 @@ public class DoiServiceTest extends IntegrationTest {
             }
 
             //and that there is only one of them in the database
-            //try (ElideDataStorePassClient passClient = getNewClient()) {
             filter = RSQL.equals("journalName", name);
             result = passClient.
                 selectObjects(new PassClientSelector<>(Journal.class, 0, 100, filter, null));

--- a/pass-core-main/src/test/java/org/eclipse/pass/doi/service/DoiServiceTest.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/doi/service/DoiServiceTest.java
@@ -53,6 +53,7 @@ public class DoiServiceTest extends IntegrationTest {
         Call call = httpClient.newCall(okHttpRequest);
         try (Response okHttpResponse = call.execute()) {
             assertEquals(400, okHttpResponse.code());
+            assert okHttpResponse.body() != null;
             assertEquals("{\"error\":\"Supplied DOI is not in valid DOI format.\"}",
                          okHttpResponse.body().string());
 
@@ -75,6 +76,7 @@ public class DoiServiceTest extends IntegrationTest {
         Call call = httpClient.newCall(okHttpRequest);
         try (Response okHttpResponse = call.execute()) {
             assertEquals(400, okHttpResponse.code());
+            assert okHttpResponse.body() != null;
             assertEquals("{\"error\":\"Supplied DOI is not in valid DOI format.\"}",
                          okHttpResponse.body().string());
 
@@ -97,6 +99,7 @@ public class DoiServiceTest extends IntegrationTest {
         Call call = httpClient.newCall(okHttpRequest);
         try (Response okHttpResponse = call.execute()) {
             assertEquals(404, okHttpResponse.code());
+            assert okHttpResponse.body() != null;
             assertEquals("{\"error\":\"The resource for DOI 10.1212/abc.DEF could not be found on Crossref.\"}",
                          okHttpResponse.body().string());
 
@@ -122,13 +125,14 @@ public class DoiServiceTest extends IntegrationTest {
         Call call = httpClient.newCall(okHttpRequest);
         try (Response okHttpResponse = call.execute()) {
             assertEquals(422, okHttpResponse.code());
+            assert okHttpResponse.body() != null;
             assertEquals("{\"error\":\"Insufficient information to locate or specify a journal entry.\"}",
                          okHttpResponse.body().string());
         }
     }
 
     @Test
-    public void realJournalTest() throws Exception {
+    public void realJournalTest() {
         String name = "Clinical Medicine Insights: Cardiology";
         HttpUrl url = formDoiUrl("10.4137/cmc.s38446" );
         String id = "";
@@ -137,7 +141,7 @@ public class DoiServiceTest extends IntegrationTest {
             //if this journal is in the database already, delete it
             String filter = RSQL.equals("journalName", name);
             PassClientResult<Journal> result = passClient.
-                selectObjects(new PassClientSelector<Journal>(Journal.class, 0, 100, filter, null));
+                selectObjects(new PassClientSelector<>(Journal.class, 0, 100, filter, null));
             result.getObjects().forEach(j -> {
                 try {
                     passClient.deleteObject(Journal.class, j.getId());
@@ -149,7 +153,7 @@ public class DoiServiceTest extends IntegrationTest {
             //verify that this journal is not in the database
             filter = RSQL.equals("journalName", name);
             result = passClient.
-                selectObjects(new PassClientSelector<Journal>(Journal.class, 0, 100, filter, null));
+                selectObjects(new PassClientSelector<>(Journal.class, 0, 100, filter, null));
             assertEquals(0, result.getObjects().size());
 
             Request okHttpRequest = new Request.Builder()
@@ -159,6 +163,7 @@ public class DoiServiceTest extends IntegrationTest {
             Call call = httpClient.newCall(okHttpRequest);
             try (Response okHttpResponse = call.execute()) {
                 assertEquals(200, okHttpResponse.code());
+                assert okHttpResponse.body() != null;
                 JsonReader jsonReader1 = Json.createReader(new StringReader(okHttpResponse.body().string()));
                 JsonObject successReport = jsonReader1.readObject();
                 jsonReader1.close();
@@ -168,7 +173,7 @@ public class DoiServiceTest extends IntegrationTest {
                 //verify that this journal is now in the database
                 filter = RSQL.equals("journalName", name);
                 result = passClient.
-                    selectObjects(new PassClientSelector<Journal>(Journal.class, 0, 100, filter, null));
+                    selectObjects(new PassClientSelector<>(Journal.class, 0, 100, filter, null));
                 assertEquals(1, result.getObjects().size());
             } catch (Exception e) {
                 e.printStackTrace();
@@ -177,6 +182,7 @@ public class DoiServiceTest extends IntegrationTest {
             //verify that the returned object for the same request has the right id
             call = httpClient.newCall(okHttpRequest);
             try (Response okHttpResponse = call.execute()) {
+                assert okHttpResponse.body() != null;
                 JsonReader jsonReader2 = Json.createReader(new StringReader(okHttpResponse.body().string()));
                 JsonObject successReport = jsonReader2.readObject();
                 jsonReader2.close();
@@ -189,7 +195,7 @@ public class DoiServiceTest extends IntegrationTest {
             //try (ElideDataStorePassClient passClient = getNewClient()) {
             filter = RSQL.equals("journalName", name);
             result = passClient.
-                selectObjects(new PassClientSelector<Journal>(Journal.class, 0, 100, filter, null));
+                selectObjects(new PassClientSelector<>(Journal.class, 0, 100, filter, null));
             assertEquals(1, result.getObjects().size());
         } catch (Exception e) {
             e.printStackTrace();
@@ -197,15 +203,14 @@ public class DoiServiceTest extends IntegrationTest {
     }
 
     private HttpUrl formDoiUrl(String doi) {
-        HttpUrl url = new HttpUrl.Builder()
+
+        return new HttpUrl.Builder()
             .scheme("http")
             .host("localhost")
             .port(port)
             .addPathSegment("journal")
             .addQueryParameter("doi", doi)
             .build();
-
-        return url;
     }
 
 }


### PR DESCRIPTION
Some refactoring done here to more easily accomodate multiple doi-based services in the RestController.
Close attention needs to be paid to the form of returned JSON objects to the UI to be sure structure and escaping
are as expected by pass-ui.