### PR TITLE
Add Curl to Docker image

### DIFF
--- a/pass-core-main/Dockerfile
+++ b/pass-core-main/Dockerfile
@@ -1,5 +1,8 @@
 FROM openjdk:11-jre-slim
 
+RUN apt update \
+    && apt install -y curl
+
 WORKDIR /app
 
 COPY target/pass-core-main.jar .


### PR DESCRIPTION
* Used with a healthcheck to enable docker compose to wait for container init

Example compose file:

``` yml
services:
  pass-core:
    image: ghcr.io/eclipse-pass/pass-core
    ...
    healthcheck:
      test: "curl -f http://localhost:8080/data/user || exit 1"
      start_period: 30s
```

This would try the URL (which should use env vars) to do a simple healthcheck. When running docker compose with the `--wait` flag, the process will stall until the healthcheck either passes or fails. The healthcheck test has a few retries and timeout defaults set, though we could customize that as well