### PR TITLE
Add draft snapshot and release gh actions

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -6,11 +6,6 @@ on:
       - 'main'
   workflow_dispatch:
 
-# Will need to have someone with admin permissions to add some secrets:
-# Credentials for Sonatype, needs a Sonatype account. Use Jim's for testing?
-#   - OSSRH_USERNAME
-#   - OSSRH_TOKEN
-
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -28,8 +23,7 @@ jobs:
           server-password: MAVEN_PASSWORD
 
       - name: Publish SNAPSHOT
-        # maven publish command goes here
-        run: mvn --batch-mode deploy
+        run: mvn deploy
         env:
           # Add OSSRH_USERNAME and OSSRH_TOKEN as GH secrets
           # https://docs.github.com/en/actions/security-guides/encrypted-secrets

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -1,0 +1,37 @@
+name: Publish SNAPSHOT to Sonatype
+
+on:
+  push:
+    branches:
+      - 'main'
+  workflow_dispatch:
+
+# Will need to have someone with admin permissions to add some secrets:
+# Credentials for Sonatype, needs a Sonatype account. Use Jim's for testing?
+#   - OSSRH_USERNAME
+#   - OSSRH_TOKEN
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup Java & Maven
+        uses: actions/setup-java@v3
+        with:
+          java-version: 11
+          server-id: ossrh
+          # User/pass refer to ENV VARs set below
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+      
+      - name: Publish SNAPSHOT
+        # maven publish command goes here
+        run: mvn --batch-mode deploy
+        env:
+          # Add OSSRH_USERNAME and OSSRH_TOKEN as GH secrets
+          # https://docs.github.com/en/actions/security-guides/encrypted-secrets
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -1,9 +1,9 @@
 name: Publish SNAPSHOT to Sonatype
 
 on:
-  push:
-    branches:
-      - 'main'
+  # push:
+  #   branches:
+  #     - 'main'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -26,7 +26,7 @@ jobs:
           # User/pass refer to ENV VARs set below
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
-      
+
       - name: Publish SNAPSHOT
         # maven publish command goes here
         run: mvn --batch-mode deploy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Publish release
         run: |
-          mvn release:prepare -DreleaseVersion=$RELEASE -Dtag=$RELEASE -DdevelopmentVersion=$NEXT -DautoVersionSubmodules=true
+          mvn --batch-mode release:prepare -DreleaseVersion=$RELEASE -Dtag=$RELEASE -DdevelopmentVersion=$NEXT -DautoVersionSubmodules=true
           mvn release:perform -Dgoals=deploy 
         env:
           # Add OSSRH_USERNAME and OSSRH_TOKEN as GH secrets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+# Release artifact will be pushed to Sonatype, which is synced to
+# Maven Central
+name: Publish a release to Maven Central
+
+on:
+  # We can use very similiar workflow to manually trigger a full publish
+  # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_dispatchinputs
+  workflow_dispatch:
+    inputs:
+      releaseversion:
+        description: 'Release version'
+        required: true
+      nextversion:
+        description: 'Next dev version'
+        required: true
+
+# Will need to have someone with admin permissions to add some secrets:
+# Credentials for Sonatype, needs a Sonatype account. Use Jim's for testing?
+#   - OSSRH_USERNAME
+#   - OSSRH_TOKEN
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    # Can we check to make sure $NEXT doesn't already exist as a tag?
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup Java & Maven
+        uses: actions/setup-java@v3
+        with:
+          java-version: 11
+          server-id: ossrh
+          # User/pass refer to ENV VARs set below
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+      
+      - name: Publish release
+        # maven publish command goes here
+        run: |
+          mvn release:prepare -DreleaseVersion=$RELEASE -Dtag=$RELEASE -DdevelopmentVersion=$NEXT 
+          mvn release:perform -Dgoals=deploy 
+        env:
+          # Add OSSRH_USERNAME and OSSRH_TOKEN as GH secrets
+          # https://docs.github.com/en/actions/security-guides/encrypted-secrets
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          RELEASE: ${{ inputs.releaseversion }}
+          NEXT: ${{ inputs.nextversion }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,12 +18,20 @@ on:
 # Credentials for Sonatype, needs a Sonatype account. Use Jim's for testing?
 #   - OSSRH_USERNAME
 #   - OSSRH_TOKEN
+# Also need credentials for pushing Docker images to GHCR
+#   - GHCR_USERNAME (do usernames need to be in secrets?)
+#   - GHCR_TOKEN
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     # Can we check to make sure $NEXT doesn't already exist as a tag?
     steps:
+      - name: Configure git
+        run: |
+          git config user.name "GH Action | Release"
+          git config user.email "<>"
+
       - name: Checkout code
         uses: actions/checkout@v3
 
@@ -35,11 +43,19 @@ jobs:
           # User/pass refer to ENV VARs set below
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
-      
-      - name: Publish release
-        # maven publish command goes here
+            
+      - name: Bump version to release
+        run: mvn versions:update-parent
+
+      - name: Commit release version bump
         run: |
-          mvn release:prepare -DreleaseVersion=$RELEASE -Dtag=$RELEASE -DdevelopmentVersion=$NEXT 
+          git add **/pom.xml
+          git commit -m "Update parent version to ${{ inputs.releaseversion }}"
+          git push origin main
+
+      - name: Publish release
+        run: |
+          mvn release:prepare -DreleaseVersion=$RELEASE -Dtag=$RELEASE -DdevelopmentVersion=$NEXT -DautoVersionSubmodules=true
           mvn release:perform -Dgoals=deploy 
         env:
           # Add OSSRH_USERNAME and OSSRH_TOKEN as GH secrets
@@ -48,3 +64,19 @@ jobs:
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
           RELEASE: ${{ inputs.releaseversion }}
           NEXT: ${{ inputs.nextversion }}
+
+      - name: Push release tag
+        run: git push origin --tags
+
+      - name: Update to new dev version and push to GH
+        # TODO: Don't we need to `git add ...` the POMs first?
+        run: |
+          mvn versions:update-parent -DallowSnapshots=true
+          git push origin main
+
+      # TODO: need to update username / credentials
+      - name: Login to GHCR
+        run: echo ${{ secrets.GHCR_TOKEN }} | docker login ghcr.io --username ${{ secrets.GHCR_USERNAME }} --password-stdin
+
+      - name: Push Docker image to GHCR
+        run: docker push ghcr.io/eclipse-pass/pass-core-main:${{ inputs.releaseversion }}


### PR DESCRIPTION
Relates to https://github.com/eclipse-pass/main/issues/235

* Add new GitHub actions intended to publish to Sonatype. One for SNAPSHOT, separate one for full release
* SNAPSHOT publish will run on commit/merge in `main`
* Full release will run manually only, require input of release version and next dev version #'s

## Questions
@jrmartino Can you check the maven commands? 
* [SNAPSHOT command](https://github.com/eclipse-pass/pass-core/blob/235-sonatype-automation/.github/workflows/publish-snapshot.yml#L32)
* [Release commands](https://github.com/eclipse-pass/pass-core/blob/235-sonatype-automation/.github/workflows/release.yml#L42-L43)

I know the release commands are incomplete (minimum would require user input) and aren't yet setup to update sub-module versions correctly

## TODO
* Release action also incomplete, as we'd probably want the GH Action to push the new release tag to the GH repo, possibly create a new Docker image
* ~Both GH Actions require credentials in the form of GH secrets (https://docs.github.com/en/actions/security-guides/encrypted-secrets) which I do not have access to. Will need to poke someone else to handle this or open a ticket with Eclipse HelpDesk~ OSSHR_USERNAME and OSSRH_PASSWORD secrets are in place for `pass-core`. Other secrets will need to be added later

## Testing
Please focus on the `publish-snapshot` action. This will provide a PoC for handling Sonatype credentials. If the snapshots can get published with this action, then I can move onto making sure the full release can function.

There's no real way of testing this out until it's merged into `main`, at which point, we'll have a button to run the workflow(s) manually in the GH UI.