### PR TITLE
Added .gitattributes for LF line breaks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+entrypoint.sh text eol=lf
+init_postgres.sh text eol=lf


### PR DESCRIPTION
Docker requires entrypoint.sh and init_postgres.sh to have LF line breaks. Git on windows by default will checkout CRLF style and will cause Docker to bork.