### PR TITLE
408 - Added chmod to the entrypoint in Dockerfile

### DIFF
--- a/pass-core-main/Dockerfile
+++ b/pass-core-main/Dockerfile
@@ -1,11 +1,13 @@
 FROM openjdk:11-jre-slim
 
-RUN apt update \
-    && apt install -y curl
-
 WORKDIR /app
 
 COPY target/pass-core-main.jar .
 COPY entrypoint.sh .
+
+RUN apt update \
+    && apt install -y curl \
+    && chmod +x entrypoint.sh \
+    && rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT ["./entrypoint.sh"]


### PR DESCRIPTION
On a windows machine the execute permission gets removed during the maven image build. This error occurs after building an image from the maven process. 

Error response from daemon: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "./entrypoint.sh": permission denied: un
known

To remedy this issue a chmod +x is added to the Dockerfile. 

Tested locally in Docker. Pass-core run in docker and able to POST/GET a grant.