### PR TITLE
Set pass-core-main image used by docker-compose.yml to 0.3.0-SNAPSHOT

### DIFF
--- a/pass-core-main/docker-compose.yml
+++ b/pass-core-main/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - db:/var/lib/postgresql/data
       - ./init_postgres.sh:/docker-entrypoint-initdb.d/init_postgres.sh
   core:
-    image: ghcr.io/eclipse-pass/pass-core-main:${project.version}
+    image: ghcr.io/eclipse-pass/pass-core-main:0.3.0-SNAPSHOT
     build:
       context: .
     env_file: .env


### PR DESCRIPTION
Should also update release notes to set this value.