### PR TITLE
Update snapshot publish action

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -1,11 +1,9 @@
 name: Publish SNAPSHOT to Sonatype
-# TODO: Not quite complete. Need to make sure current version is a SNAPSHOT version
-# before proceeding with the publishing - because there will be some commits on `main`
-# that will be associated with full releases
+
 on:
-  # push:
-  #   branches:
-  #     - 'main'
+  push:
+    branches:
+      - 'main'
   workflow_dispatch:
 
 jobs:
@@ -22,15 +20,31 @@ jobs:
           java-version: 11
           server-id: ossrh
           # User/pass refer to ENV VARs set below
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
+          server-username: MAVEN_USERNAME # Sonatype user
+          server-password: MAVEN_PASSWORD # Sonatype password # env variable for GPG private key passphrase
+      
+      - name: Get project version
+        id: project_version
+        # run: echo ::set-output name=version::$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+        run: echo "VERSION=`mvn help:evaluate -Dexpression=project.version -q -DforceStdout`" >> $GITHUB_OUTPUT
 
       - name: Publish SNAPSHOT
-        run: |
-          cat ~/.m2/settings.xml
-          mvn -B --no-transfer-progress clean deploy
+        # Only execute for -SNAPSHOT versions
+        if:  ${{ endsWith(steps.project_version.outputs.version, '-SNAPSHOT') }}
+        run: mvn -B --no-transfer-progress clean deploy
         env:
           # Add OSSRH_USERNAME and OSSRH_PASSWORD as GH secrets
           # https://docs.github.com/en/actions/security-guides/encrypted-secrets
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+
+      # Update pass-core-main:latest Docker image
+      - name: Login to GHCR
+        run: echo ${{ secrets.PASS_DOCKER_TOKEN }} | docker login ghcr.io --username ${{ secrets.PASS_DOCKER_USER }} --password-stdin
+      - name: Get newly built Docker image tag
+        id: image_tag
+        run: echo "IMAGE_TAG=`docker images ghcr.io/eclipse-pass/pass-core-main --no-trunc --format {{.Tag}}`" >> $GITHUB_OUTPUT
+      - name: Push new image as :latest
+        run: |
+          docker tag ghcr.io/eclipse-pass/pass-core-main:${{ steps.image_tag.outputs.IMAGE_TAG }} ghcr.io/eclipse-pass/pass-core-main:latest
+          docker push ghcr.io/eclipse-pass/pass-core-main:latest

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -22,6 +22,8 @@ jobs:
           # User/pass refer to ENV VARs set below
           server-username: MAVEN_USERNAME # Sonatype user
           server-password: MAVEN_PASSWORD # Sonatype password # env variable for GPG private key passphrase
+          gpg-private-key: ${{ secrets.MAVEN_GPG_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
       
       - name: Get project version
         id: project_version
@@ -37,3 +39,4 @@ jobs:
           # https://docs.github.com/en/actions/security-guides/encrypted-secrets
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -1,5 +1,7 @@
 name: Publish SNAPSHOT to Sonatype
-
+# TODO: Not quite complete. Need to make sure current version is a SNAPSHOT version
+# before proceeding with the publishing - because there will be some commits on `main`
+# that will be associated with full releases
 on:
   # push:
   #   branches:
@@ -16,6 +18,7 @@ jobs:
       - name: Setup Java & Maven
         uses: actions/setup-java@v3
         with:
+          distribution: 'temurin'
           java-version: 11
           server-id: ossrh
           # User/pass refer to ENV VARs set below
@@ -23,9 +26,11 @@ jobs:
           server-password: MAVEN_PASSWORD
 
       - name: Publish SNAPSHOT
-        run: mvn deploy
+        run: |
+          cat ~/.m2/settings.xml
+          mvn -B --no-transfer-progress clean deploy
         env:
-          # Add OSSRH_USERNAME and OSSRH_TOKEN as GH secrets
+          # Add OSSRH_USERNAME and OSSRH_PASSWORD as GH secrets
           # https://docs.github.com/en/actions/security-guides/encrypted-secrets
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -37,14 +37,3 @@ jobs:
           # https://docs.github.com/en/actions/security-guides/encrypted-secrets
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
-
-      # Update pass-core-main:latest Docker image
-      - name: Login to GHCR
-        run: echo ${{ secrets.PASS_DOCKER_TOKEN }} | docker login ghcr.io --username ${{ secrets.PASS_DOCKER_USER }} --password-stdin
-      - name: Get newly built Docker image tag
-        id: image_tag
-        run: echo "IMAGE_TAG=`docker images ghcr.io/eclipse-pass/pass-core-main --no-trunc --format {{.Tag}}`" >> $GITHUB_OUTPUT
-      - name: Push new image as :latest
-        run: |
-          docker tag ghcr.io/eclipse-pass/pass-core-main:${{ steps.image_tag.outputs.IMAGE_TAG }} ghcr.io/eclipse-pass/pass-core-main:latest
-          docker push ghcr.io/eclipse-pass/pass-core-main:latest

--- a/.github/workflows/update-image.yml
+++ b/.github/workflows/update-image.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           java-version: 11
       - name: "Log into GHCR"
-        run: echo ${{ secrets.pass_docker_pat }} | docker login ghcr.io --username grant-mcs --password-stdin
+        run: echo ${{ secrets.PASS_DOCKER_TOKEN }} | docker login ghcr.io --username ${{ secrets.PASS_DOCKER_USER }} --password-stdin
       - name: "Build and upload new package"
         run: mvn clean verify
       - name: "Get image tag"
@@ -43,10 +43,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: eclipse-pass/pass-docker
-          token: ${{ secrets.pass_docker_pat }}
+          token: ${{ secrets.PASS_DOCKER_TOKEN }}
       - uses: oleksiyrudenko/gha-git-credentials@v2-latest
         with:
-          token: ${{ secrets.pass_docker_pat }}
+          token: ${{ secrets.PASS_DOCKER_TOKEN }}
       - name: Update nightly server config
         run: python tools/update-image.py eclipse-pass.nightly.yml pass-core "ghcr.io/eclipse-pass/pass-core-main:${{ steps.image_tag.outputs.IMAGE_TAG }}@${{ steps.image_hash.outputs.IMAGE_HASH }}"
       - name: Commit change (if any)


### PR DESCRIPTION
## Changes

* Only run action for `*-SNAPSHOT` versions, as defined in the POM
* Update update-image action to accept secret for GHCR login user
* publish-snapshot will run on merge to `main`
* Should now work as intended
* GPG artifact signing should be configured and working now

Future work: 
* Promote secrets to organization level, so they can be used in `main` and `pass-support` (and wherever else necessary)