### PR TITLE
Modified gitattributes to use LF for all .sh files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
-entrypoint.sh text eol=lf
-init_postgres.sh text eol=lf
+*.sh text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
+# in case image is built on Windows to force Linux-style shell line-endings for shell scripts: Entrypoint, init_postgres
 *.sh text eol=lf


### PR DESCRIPTION
After even more testing the final conclusion is:

- whether in the entrypoint.sh it is `#! /bin/bash` or `#! /bin/sh` - the line endings still matter
- gitattributes is necessary for windows env to run the mvn produced docker image 
- to future proof this issue with windows developers making all .sh files use LF line endings will prevent any future issues
