### PR TITLE
Allow the submitter role to update Publications

### DIFF
--- a/pass-core-main/src/test/java/org/eclipse/pass/main/security/AccessControlTest.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/main/security/AccessControlTest.java
@@ -314,7 +314,7 @@ public class AccessControlTest extends ShibIntegrationTest {
 
             Response response = client.newCall(request).execute();
 
-            check(response, 403);
+            check(response, 204);
         }
 
         {

--- a/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/Publication.java
+++ b/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/Publication.java
@@ -23,6 +23,7 @@ import javax.persistence.Table;
 
 import com.yahoo.elide.annotation.CreatePermission;
 import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.annotation.UpdatePermission;
 
 /**
  * Publication model. Contains details of work being submitted, where it is being deposited to, related Grants etc.
@@ -31,6 +32,7 @@ import com.yahoo.elide.annotation.Include;
  */
 
 @CreatePermission(expression = "User is Backend OR User is Submitter")
+@UpdatePermission(expression = "User is Backend OR User is Submitter")
 @Include
 @Entity
 @Table(name = "pass_publication")


### PR DESCRIPTION
This small permission change allows anyone with the submitter role to update any publication.