### PR TITLE
Fix JSON parsing error with unpaywall service

### DIFF
--- a/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/PassDoiServiceController.java
+++ b/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/PassDoiServiceController.java
@@ -213,7 +213,11 @@ public class PassDoiServiceController {
                 response.setStatus(500);
                 LOG.info(message);
             }
-        } else if (unpaywallJsonObject.getValue("/error").toString().equals("true") ) {
+        } else if (
+            unpaywallJsonObject.containsKey("error") &&
+            unpaywallJsonObject.getValue("/error").toString().equals("true")
+        ) {
+            LOG.debug(unpaywallJsonObject.toString());
             int responseCode;
             String message;
 


### PR DESCRIPTION
Encountered an issue when trying to integrate the `/doi/manuscript` endpoint with the UI:

Requesting `/doi/manuscript?doi=10.1039/c7an01256j` - a known good DOI
DOI service response: `{"timestamp":"2023-04-14T19:59:02.350+00:00","status":500,"error":"Internal Server Error","path":"/doi/manuscript"}`

DOI service log:
```
Caused by: javax.json.JsonException: Non-existing name/value pair in the object for key error
     at org.glassfish.json.NodeReference$ObjectReference.get(NodeReference.java:221)
     at org.glassfish.json.JsonPointerImpl.getValue(JsonPointerImpl.java:160)
     at javax.json.JsonStructure.getValue(JsonStructure.java:60)
     at org.eclipse.pass.doi.service.PassDoiServiceController.getUnpaywallMetadata(PassDoiServiceController.java:218)
```

This simply checks for the presence of the `error` property on the Unpaywall response before checking the property value to make sure the property exists