### PR TITLE
Update metadata schemas service response

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The [file service](pass-core-file-service/README.md) provides a mechanism to per
 
 # Metadata Schema service
 
-The [metadata schema service](pass-core-metadataschema-service/README.md) provides a mechanism to persist files.
+The [metadata schema service](pass-core-metadataschema-service/README.md) provides JSON schemas intended to describe PASS submission metadata
 
 # JSON API
 

--- a/pass-core-main/src/test/resources/schemas/jhu/common.json
+++ b/pass-core-main/src/test/resources/schemas/jhu/common.json
@@ -1,0 +1,55 @@
+{
+    "title": "JHU common schema",
+    "description": "Enumerates the common properties required by most repositories",
+    "$id": "https://eclipse-pass.github.io/pass-metadata-schemas/schemas/jhu/common.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "definitions": {
+        "form": {
+            "type": "object",
+            "title": "Publication Details <br><p class='lead text-muted'>Please provide additional information about your article/manuscript below. If DOI was provided in the initial step of the submission, the metadata associated with that DOI was found and used to prepopulatethis form. </p> <p class='lead text-muted'> <i class='glyphicon glyphicon-info-sign'></i> Fields that are not editable were populated using metadata associated with the provided DOI. </p>",
+            "$comment": "These properties are intended to be displayed in an Alpaca form",
+            "properties": {
+                "title": {
+                    "$ref": "global.json#/properties/title"
+                },
+                "journal-title": {
+                    "$ref": "global.json#/properties/journal-title"
+                },
+                "volume": {
+                    "$ref": "global.json#/properties/volume"
+                },
+                "issue": {
+                    "$ref": "global.json#/properties/issue"
+                },
+                "issns": {
+                    "$ref": "global.json#/properties/issns"
+                },
+                "publisher": {
+                    "$ref": "global.json#/properties/publisher"
+                },
+                "publicationDate": {
+                    "$ref": "global.json#/properties/publicationDate"
+                },
+                "abstract": {
+                    "$ref": "global.json#/properties/abstract"
+                },
+                "authors": {
+                    "$ref": "global.json#/properties/authors"
+                },
+                "under-embargo": {
+                    "$ref": "global.json#/properties/under-embargo"
+                },
+                "Embargo-end-date": {
+                    "$ref": "global.json#/properties/Embargo-end-date"
+                }
+            },
+            "dependencies": {
+                "Embargo-end-date": ["under-embargo"]
+            },
+            "options": {
+                "$ref": "global.json#/options"
+            }
+        }
+    }
+}

--- a/pass-core-main/src/test/resources/schemas/jhu/global.json
+++ b/pass-core-main/src/test/resources/schemas/jhu/global.json
@@ -1,0 +1,298 @@
+{
+    "title": "JHU global schema",
+    "description": "Defines all possible metadata fields for PASS deposit",
+    "$id": "https://eclipse-pass.github.io/pass-metadata-schemas/schemas/jhu/global.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "required": [
+        "$schema",
+        "title",
+        "journal-title"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "$schema": {
+            "type": "string",
+            "title": "JSON schema",
+            "description": "The JSON schema that applies to the resulting metadata blob"
+        },
+        "agreements": {
+            "type": "object",
+            "title": "Agreements to deposit conditions",
+            "description": "Maps repository keys to the text or links containing the agreements accepted by the submitter",
+            "$comment": "This was formerly known as 'embargo', available only for JScholarship metadata",
+            "patternProperties": {
+                "^.+$": {
+                    "type": "string",
+                    "title": "Agreement",
+                    "description": "Text or link agreed to for the given repository key",
+                    "$comment": "Example: {'jScholarship': 'http://example.org/agreementText'}"
+                }
+            }
+        },
+        "abstract": {
+            "type": "string",
+            "title": "Abstract",
+            "description": "The abstract of the article or manuscript being submitted"
+        },
+        "agent_information": {
+            "type": "object",
+            "title": "User agent (browser) information",
+            "description": "Contains the identity and version of the user's browser",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "title": "User agent (browser) name"
+                },
+                "version": {
+                    "type": "string",
+                    "title": "User agent (browser) version"
+                }
+            }
+        },
+        "authors": {
+            "type": "array",
+            "title": "Authors of this article or manuscript",
+            "description": "List of authors and their associated ORCIDS, if available",
+            "uniqueItems": true,
+            "items": {
+                "type": "object",
+                "title": "Author",
+                "properties": {
+                    "author": {
+                        "type": "string"
+                    },
+                    "orcid": {
+                        "type": "string"
+                    }
+                },
+                "required": ["author"]
+            }
+        },
+        "doi": {
+            "type": "string",
+            "pattern": "^10\\..+?/.+?$",
+            "title": "DOI of article",
+            "description": "The DOI of the individual article or manuscript submitted"
+        },
+        "Embargo-end-date": {
+            "type": "string",
+            "format": "date",
+            "title": "Embargo end date",
+            "description": "Date at which the article or manuscript may be made public"
+        },
+        "hints": {
+            "type": "object",
+            "title": "Hints provided by the UI to backend services",
+            "description": "Hints have semantics shared by the UI and the backend that are intended to influence the backend processing of the submission.",
+            "additionalProperties": false,
+            "properties": {
+                "collection-tags": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "title": "Tags impacting the collection used by Deposit Services for deposit",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "journal-NLMTA-ID": {
+            "type": "string",
+            "title": "NTMLA",
+            "description": "NLM identifier for a journal"
+        },
+        "journal-title": {
+            "type": "string",
+            "title": "Journal title",
+            "description": "Title of the journal the individual article or manuscript was submitted to"
+        },
+        "journal-title-short": {
+            "type": "string",
+            "title": "Short journal title",
+            "description": "Short journal title from CrossRef"
+        },
+        "issue": {
+            "type": "string",
+            "title": "Journal issue",
+            "description": "Issue number of the journal this article or manuscript was submitted to"
+        },
+        "issns": {
+            "type": "array",
+            "title": "ISSN information for the manuscript's journal",
+            "description": "List of ISSN numbers with optional publication type",
+            "uniqueItems": true,
+            "items": {
+                "type": "object",
+                "title": "ISSN info",
+                "properties": {
+                    "issn": {
+                        "type": "string",
+                        "title": "ISSN "
+                    },
+                    "pubType": {
+                        "type": "string",
+                        "title": "publication type",
+                        "enum": ["Print", "Online"]
+                    }
+                }
+            }
+        },
+        "publisher": {
+            "type": "string",
+            "title": "Publisher",
+            "description": "Publisher of the journal this article or manuscript was submitted to"
+        },
+        "publicationDate": {
+            "type": "string",
+            "title": "Publication Date",
+            "description": "Publication date of the journal or article this manuscript was submitted to",
+            "$comment": "This was formerly date-time format, but that appears too precise for values like 'Summer 2018'"
+        },
+        "title": {
+            "type": "string",
+            "title": "Article / Manuscript Title",
+            "description": "The title of the individual article or manuscript that was submitted"
+        },
+        "under-embargo": {
+            "type": "string",
+            "title": "Under Embargo",
+            "description": "Indicates wither the article or manuscript is under embargo",
+            "$comment": "This should probably be a boolean"
+        },
+        "volume": {
+            "type": "string",
+            "title": "Journal Volume",
+            "description": "journal volume this article or manuscript was published in"
+        }
+    },
+    "dependencies": {
+        "Embargo-end-date": ["under-embargo"]
+    },
+    "options": {
+        "fields": {
+            "title": {
+                "type": "textarea",
+                "label": "Article / Manuscript Title <small class=\"text-muted\">(required)</small>",
+                "placeholder": "Enter the manuscript title",
+                "rows": 2,
+                "cols": 100,
+                "hidden": false,
+                "order": 1
+            },
+            "journal-title": {
+                "type": "text",
+                "label": "Journal Title <small class=\"text-muted\">(required)</small>",
+                "placeholder": "Enter the journal title",
+                "hidden": false,
+                "order": 2
+            },
+            "journal-NLMTA-ID": {
+                "type": "text",
+                "label": "Journal NLMTA ID <small class=\"text-muted\">(optional)</small>",
+                "placeholder": "nlmta",
+                "order": 3
+            },
+            "volume": {
+                "type": "text",
+                "label": "Volume  <small class=\"text-muted\">(optional)</small>",
+                "placeholder": "Enter the volume",
+                "hidden": false,
+                "order": 4
+            },
+            "issue": {
+                "type": "text",
+                "label": "Issue  <small class=\"text-muted\">(optional)</small>",
+                "placeholder": "Enter issue",
+                "hidden": false,
+                "order": 5
+            },
+            "issns": {
+                "label": "<div>ISSN Information</div><hr/>",
+                "hidden": false,
+                "fieldClass": "",
+                "items": {
+                    "label": "<span class=\"d-none\"></span>",
+                    "fieldClass": "row",
+                    "fields": {
+                        "issn": {
+                            "label": "ISSN",
+                            "fieldClass": "body-text col-6 pull-left "
+                        },
+                        "pubType": {
+                            "label": "Publication Type",
+                            "fieldClass": "body-text col-6 pull-left md-pubtype",
+                            "vertical": false,
+                            "removeDefaultNone": true
+                        }
+                    }
+                },
+                "order": 6
+            },
+            "publisher": {
+                "type": "text",
+                "label": "Publisher <small class=\"text-muted\">(optional)</small>",
+                "placeholder": "Enter the Publisher",
+                "hidden": false,
+                "order": 7
+            },
+            "publicationDate": {
+                "type": "date",
+                "label": "Publication Date  <small class=\"text-muted\">(optional)</small>",
+                "hidden": false,
+                "order": 8
+            },
+            "abstract": {
+                "type": "textarea",
+                "label": "Abstract <small class=\"text-muted\">(optional)</small>",
+                "placeholder": "Enter abstract",
+                "fieldClass": "clearfix",
+                "hidden": false,
+                "order": 9
+            },
+            "authors": {
+                "label": "<div>Authors</div><hr/>",
+                "hidden": false,
+                "items": {
+                    "label": "<span class=\"d-none\"></span>",
+                    "fields": {
+                        "author": {
+                            "label": "Name",
+                            "fieldClass": "body-text col-6 pull-left pl-0"
+                        },
+                        "orcid": {
+                            "label": "ORCiD",
+                            "fieldClass": "body-text col-6 pull-left pr-0"
+                        }
+                    }
+                },
+                "order": 10
+            },
+            "under-embargo": {
+                "type": "checkbox",
+                "rightLabel": "The material being submitted is published under an embargo.",
+                "fieldClass": "m-0 mt-4",
+                "hidden": false,
+                "order": 11
+            },
+            "Embargo-end-date": {
+                "type": "date",
+                "label": "Embargo End Date",
+                "helper": "<i>After the embargo end date, your submission manuscripts or article can be made public. <b>If this publication is not under embargo, please leave this field blank.<b></i>",
+                "helpersPosition": "above",
+                "placeholder": "dd/mm/yyyy",
+                "validate": true,
+                "inputType": "date",
+                "fieldClass": "date-time-picker",
+                "picker": {
+                    "format": "MM/DD/YY",
+                    "allowInputToggle": true
+                },
+                "order": 12,
+                "dependencies": {
+                    "under-embargo": true
+                }
+            }
+        }
+    }
+}

--- a/pass-core-main/src/test/resources/schemas/jhu/jscholarship.json
+++ b/pass-core-main/src/test/resources/schemas/jhu/jscholarship.json
@@ -1,0 +1,30 @@
+{
+    "title": "JScholarship schema",
+    "description": "JScholarship-specific metadata requirements",
+    "$id": "https://eclipse-pass.github.io/pass-metadata-schemas/schemas/jhu/jscholarship.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "definitions": {
+        "form": {
+            "title": "Johns Hopkins - JScholarship <br><p class='lead text-muted'>Deposit requirements for JH's institutional repository JScholarship</p>",
+            "type": "object",
+            "properties": {
+                "authors": {
+                    "$ref": "global.json#/properties/authors"
+                }
+            },
+            "required": ["authors"]
+        },
+        "options": {
+            "$ref": "global.json#/options"
+        }
+    },
+    "allOf": [
+        {
+            "$ref": "global.json#"
+        },
+        {
+            "$ref": "#/definitions/form"
+        }
+    ]
+}

--- a/pass-core-main/src/test/resources/schemas/jhu/nihms.json
+++ b/pass-core-main/src/test/resources/schemas/jhu/nihms.json
@@ -1,0 +1,75 @@
+{
+    "title": "NIHMS schema",
+    "description": "NIHMS-specific metadata requirements",
+    "$id": "https://eclipse-pass.github.io/pass-metadata-schemas/schemas/jhu/nihms.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "definitions": {
+        "form": {
+            "title": "NIH Manuscript Submission System (NIHMS) <br><p class='lead text-muted'>The following metadata fields will be part of the NIHMS submission.</p>",
+            "type": "object",
+            "properties": {
+                "journal-NLMTA-ID": {
+                    "$ref": "global.json#/properties/journal-NLMTA-ID"
+                },
+                "issns": {
+                    "$ref": "global.json#/properties/issns"
+                }
+            }
+        },
+        "prerequisites": {
+            "anyOf": [
+                {"$ref": "#/definitions/nlmta_present"},
+                {"$ref": "#/definitions/issn_present"}
+            ]
+        },
+        "issn_present": {
+            "type": "object",
+            "properties": {
+                "issns": {
+                    "type": "array",
+                    "contains": {
+                        "type": "object",
+                        "required": [
+                            "issn",
+                            "pubType"
+                        ],
+                        "properties": {
+                            "issn": {
+                                "type": "string"
+                            },
+                            "pubType": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "nlmta_present": {
+            "type": "object",
+            "required": [
+                "journal-NLMTA-ID"
+            ],
+            "properties": {
+                "journal-NLMTA-ID": {
+                    "$ref": "global.json#/properties/journal-NLMTA-ID"
+                }
+            }
+        },
+        "options": {
+            "$ref": "global.json#/options"
+        }
+    },
+    "allOf": [
+        {
+            "$ref": "global.json#"
+        },
+        {
+            "$ref": "#/definitions/prerequisites"
+        },
+        {
+            "$ref": "#/definitions/form"
+        }
+    ]
+}

--- a/pass-core-metadataschema-service/src/main/java/org/eclipse/pass/metadataschema/PassSchemaServiceController.java
+++ b/pass-core-metadataschema-service/src/main/java/org/eclipse/pass/metadataschema/PassSchemaServiceController.java
@@ -103,7 +103,9 @@ public class PassSchemaServiceController {
     @GetMapping("/schema")
     public ResponseEntity<?> getSchema(@RequestParam("entityIds") String entityIds,
                                        @RequestParam("merge") String mergeSchemaOpt) throws IOException {
+        LOG.debug("Received request to retrieve schema for entityIds: {}, and merge: {}", entityIds, mergeSchemaOpt);
         if (entityIds == null || entityIds.isEmpty()) {
+            LOG.error("No entityIds provided");
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("No entityIds provided");
         }
         if (mergeSchemaOpt == null || mergeSchemaOpt.isEmpty()) {

--- a/pass-core-metadataschema-service/src/main/java/org/eclipse/pass/metadataschema/SchemaFetcher.java
+++ b/pass-core-metadataschema-service/src/main/java/org/eclipse/pass/metadataschema/SchemaFetcher.java
@@ -83,9 +83,7 @@ public class SchemaFetcher {
         // dereference each of the schemas - only perform after ordering dependencies
         for (JsonNode schema : schemas) {
             SchemaInstance s = new SchemaInstance(schema);
-            //pass in $ for root JSONpath
-            s.dereference(s.getSchema(), "$");
-            //s.dereference2(s.getSchema());
+            s.dereference(s.getSchema());
             schema_instances.add(s);
         }
 

--- a/pass-core-metadataschema-service/src/main/java/org/eclipse/pass/metadataschema/SchemaFetcher.java
+++ b/pass-core-metadataschema-service/src/main/java/org/eclipse/pass/metadataschema/SchemaFetcher.java
@@ -72,18 +72,21 @@ public class SchemaFetcher {
                 }
             }
         }
-        // dereference each of the schemas
-        for (JsonNode schema : schemas) {
-            SchemaInstance s = new SchemaInstance(schema);
-            s.dereference(s.getSchema(), "");
-            schema_instances.add(s);
-        }
 
         //order schema dependencies
         for (SchemaInstance s : schema_instances) {
             for (SchemaInstance k: schema_instances) {
                 s.updateOrderDeps(k);
             }
+        }
+
+        // dereference each of the schemas - only perform after ordering dependencies
+        for (JsonNode schema : schemas) {
+            SchemaInstance s = new SchemaInstance(schema);
+            //pass in $ for root JSONpath
+            s.dereference(s.getSchema(), "$");
+            //s.dereference2(s.getSchema());
+            schema_instances.add(s);
         }
 
         //sort schemas

--- a/pass-core-metadataschema-service/src/test/java/org/eclipse/pass/metadataschema/SchemaControllerTest.java
+++ b/pass-core-metadataschema-service/src/test/java/org/eclipse/pass/metadataschema/SchemaControllerTest.java
@@ -165,10 +165,10 @@ class SchemaControllerTest {
                 .getResourceAsStream("/schemas/jhu/expected_jscholarship_common_merge.json");
         ObjectMapper map = new ObjectMapper();
         JsonNode expected = map.readTree(expected_schema_json);
-        ArrayNode expected_array = map.createArrayNode();
-        expected_array.add(expected);
+        //ArrayNode expected_array = map.createArrayNode();
+        //expected_array.add(expected);
         JsonNode actual = map.readTree(response.getBody().toString());
-        assertEquals(expected_array, actual);
+        assertEquals(expected, actual);
     }
 
     @Test

--- a/pass-core-metadataschema-service/src/test/java/org/eclipse/pass/metadataschema/SchemaControllerTest.java
+++ b/pass-core-metadataschema-service/src/test/java/org/eclipse/pass/metadataschema/SchemaControllerTest.java
@@ -36,6 +36,7 @@ import javax.servlet.http.HttpServletRequest;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import org.eclipse.pass.object.PassClient;
 import org.eclipse.pass.object.model.Repository;
 import org.junit.jupiter.api.AfterEach;
@@ -113,7 +114,7 @@ class SchemaControllerTest {
     }
 
     @Test
-    void getSchemaTest() throws Exception {
+    void getSchemaMergeTrueTest() throws Exception {
         HttpServletRequest request = mock(HttpServletRequest.class);
 
         when(passClientMock.getObject(Repository.class, 1L)).thenReturn(repositoryMock1);
@@ -138,7 +139,46 @@ class SchemaControllerTest {
                 .getResourceAsStream("/schemas/jhu/example_merged_dereferenced.json");
         ObjectMapper map = new ObjectMapper();
         JsonNode expected = map.readTree(expected_schema_json);
+        ArrayNode expected_array = map.createArrayNode();
+        expected_array.add(expected);
         JsonNode actual = map.readTree(response.getBody().toString());
-        assertEquals(expected, actual);
+        assertEquals(expected_array, actual);
+    }
+
+    @Test
+    void getSchemaMergeFalseTest() throws Exception {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+
+        when(passClientMock.getObject(Repository.class, 1L)).thenReturn(repositoryMock1);
+        when(passClientMock.getObject(Repository.class, 2L)).thenReturn(repositoryMock2);
+
+        List<URI> r1_schemas_list = Arrays.asList(new URI("http://example.org/metadata-schemas/jhu/schema1.json"),
+                new URI("http://example.org/metadata-schemas/jhu/schema2.json"));
+
+        List<URI> r2_schemas_list = Arrays.asList(new URI("http://example.org/metadata-schemas/jhu/schema3.json"));
+
+        when(repositoryMock1.getSchemas()).thenReturn(r1_schemas_list);
+        when(repositoryMock2.getSchemas()).thenReturn(r2_schemas_list);
+
+        String repositories = "1,2";
+
+        ResponseEntity response = schemaServiceController.getSchema(repositories, "false");
+        assertEquals(response.getBody().toString(),response.getBody().toString());
+        InputStream expected_schema_json1 = SchemaServiceTest.class
+                .getResourceAsStream("/schemas/jhu/schema1.json");
+        InputStream expected_schema_json2 = SchemaServiceTest.class
+                .getResourceAsStream("/schemas/jhu/schema2.json");
+        InputStream expected_schema_json3 = SchemaServiceTest.class
+                .getResourceAsStream("/schemas/jhu/schema3.json");
+        ObjectMapper map = new ObjectMapper();
+        JsonNode expected1 = map.readTree(expected_schema_json1);
+        JsonNode expected2 = map.readTree(expected_schema_json2);
+        JsonNode expected3 = map.readTree(expected_schema_json3);
+        ArrayNode expected_array = map.createArrayNode();
+        expected_array.add(expected1);
+        expected_array.add(expected2);
+        expected_array.add(expected3);
+        JsonNode actual = map.readTree(response.getBody().toString());
+        assertEquals(expected_array, actual);
     }
 }

--- a/pass-core-metadataschema-service/src/test/java/org/eclipse/pass/metadataschema/SchemaControllerTest.java
+++ b/pass-core-metadataschema-service/src/test/java/org/eclipse/pass/metadataschema/SchemaControllerTest.java
@@ -146,6 +146,32 @@ class SchemaControllerTest {
     }
 
     @Test
+    void getSchemaMergeTrueJhuSchemaTest() throws Exception {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+
+        when(passClientMock.getObject(Repository.class, 1L)).thenReturn(repositoryMock1);
+        when(passClientMock.getObject(Repository.class, 2L)).thenReturn(repositoryMock2);
+
+        List<URI> r1_schemas_list = Arrays.asList(new URI("http://example.org/metadata-schemas/jhu/jscholarship.json"),
+                new URI("http://example.org/metadata-schemas/jhu/common.json"));
+
+        when(repositoryMock1.getSchemas()).thenReturn(r1_schemas_list);
+
+        String repositories = "1";
+
+        ResponseEntity response = schemaServiceController.getSchema(repositories, "true");
+        assertEquals(response.getBody().toString(),response.getBody().toString());
+        InputStream expected_schema_json = SchemaServiceTest.class
+                .getResourceAsStream("/schemas/jhu/expected_jscholarship_common_merge.json");
+        ObjectMapper map = new ObjectMapper();
+        JsonNode expected = map.readTree(expected_schema_json);
+        ArrayNode expected_array = map.createArrayNode();
+        expected_array.add(expected);
+        JsonNode actual = map.readTree(response.getBody().toString());
+        assertEquals(expected_array, actual);
+    }
+
+    @Test
     void getSchemaMergeFalseTest() throws Exception {
         HttpServletRequest request = mock(HttpServletRequest.class);
 

--- a/pass-core-metadataschema-service/src/test/java/org/eclipse/pass/metadataschema/SchemaFetcherTest.java
+++ b/pass-core-metadataschema-service/src/test/java/org/eclipse/pass/metadataschema/SchemaFetcherTest.java
@@ -126,15 +126,8 @@ class SchemaFetcherTest {
                 .getResourceAsStream("/schemas/jhu/schema3.json");
 
         // dereferenced version of schema_to_deref.json
-        String expectedJsonSchemaInput4 = "{\r\n"
-                + "  \"$schema\": \"http://example.org/metadata-schemas/schemas/jhu/schema_to_dereference\",\r\n"
-                + "  \"$id\": \"http://example.org/metadata-schemas/schemas/jhu/deref\",\r\n"
-                + "  \"copySchemaName\": \"http://example.org/metadata-schemas/schemas/jhu/schema_to_dereference\",\r\n"
-                + "  \"schema1_title\": \"X\",\r\n" + "  \"schema2_x\": {\r\n" + "    \"title\": \"x\",\r\n"
-                + "    \"description\": \"an awesome letter\",\r\n" + "    \"$comment\": \"displays nicely\",\r\n"
-                + "    \"type\": \"letter\"\r\n" + "},\r\n" + "  \"schema3_array\": [\"c\", \"d\", \"e\"],\r\n"
-                + "  \"schema4_complexarray\": [\"e\", \"f\", {\"g\": \"h\"}],\r\n"
-                + "  \"schema4_hk\": [\"l\", \"m\", \"m'\"]\r\n" + "}";
+        InputStream expectedJsonSchemaInput4 = SchemaFetcherTest.class
+                .getResourceAsStream("/schemas/jhu/schema_to_deref_expected.json");
 
         JsonNode expectedschema1 = map.readTree(expectedJsonSchemaInput1);
         JsonNode expectedschema2 = map.readTree(expectedJsonSchemaInput2);

--- a/pass-core-metadataschema-service/src/test/java/org/eclipse/pass/metadataschema/SchemaInstanceTest.java
+++ b/pass-core-metadataschema-service/src/test/java/org/eclipse/pass/metadataschema/SchemaInstanceTest.java
@@ -131,9 +131,7 @@ class SchemaInstanceTest {
 
         SchemaInstance testSchema = new SchemaInstance(map.readTree(example_schema_json));
         SchemaInstance expectedSchema = new SchemaInstance(map.readTree(expected));
-        //testSchema.dereference(testSchema.getSchema(), "");
-        //testSchema.dereference2(testSchema.getSchema(), "");
-        testSchema.dereference4(testSchema.getSchema());
+        testSchema.dereference(testSchema.getSchema());
         assertEquals(expectedSchema.getSchema(), testSchema.getSchema());
     }
 
@@ -147,9 +145,7 @@ class SchemaInstanceTest {
 
         SchemaInstance testSchema = new SchemaInstance(map.readTree(schemaDerefTest));
         SchemaInstance expectedSchema = new SchemaInstance(map.readTree(expectedDeref));
-        //testSchema.dereference(testSchema.getSchema(), "");
-        //testSchema.dereference2(testSchema.getSchema(), "");
-        testSchema.dereference4(testSchema.getSchema());
+        testSchema.dereference(testSchema.getSchema());
         assertEquals(expectedSchema.getSchema(), testSchema.getSchema());
     }
 
@@ -163,9 +159,7 @@ class SchemaInstanceTest {
 
         SchemaInstance testSchema = new SchemaInstance(map.readTree(schemaDerefTest));
         SchemaInstance expectedSchema = new SchemaInstance(map.readTree(expectedDeref));
-        //testSchema.dereference(testSchema.getSchema(), "");
-        //testSchema.dereference2(testSchema.getSchema(), "");
-        testSchema.dereference4(testSchema.getSchema());
+        testSchema.dereference(testSchema.getSchema());
         assertEquals(expectedSchema.getSchema(), testSchema.getSchema());
     }
 
@@ -179,12 +173,10 @@ class SchemaInstanceTest {
 
         SchemaInstance testSchema = new SchemaInstance(map.readTree(jscholarSchemaJson));
         SchemaInstance expectedSchema = new SchemaInstance(map.readTree(jscholarExpected));
-        //testSchema.dereference(testSchema.getSchema(), "");
-        //testSchema.dereference2(testSchema.getSchema(), "");
-        //testSchema.dereference3(testSchema.getSchema());
-        testSchema.dereference4(testSchema.getSchema());
+        testSchema.dereference(testSchema.getSchema());
         assertEquals(expectedSchema.getSchema(), testSchema.getSchema());
     }
+
     @Test
     void dereferenceJscholarTest() throws Exception {
         InputStream jscholarSchemaJson = SchemaInstanceTest.class
@@ -195,9 +187,7 @@ class SchemaInstanceTest {
 
         SchemaInstance testSchema = new SchemaInstance(map.readTree(jscholarSchemaJson));
         SchemaInstance expectedSchema = new SchemaInstance(map.readTree(jscholarExpected));
-        //testSchema.dereference(testSchema.getSchema(), "");
-        //testSchema.dereference2(testSchema.getSchema(), "");
-        testSchema.dereference4(testSchema.getSchema());
+        testSchema.dereference(testSchema.getSchema());
         assertEquals(expectedSchema.getSchema(), testSchema.getSchema());
     }
 

--- a/pass-core-metadataschema-service/src/test/java/org/eclipse/pass/metadataschema/SchemaInstanceTest.java
+++ b/pass-core-metadataschema-service/src/test/java/org/eclipse/pass/metadataschema/SchemaInstanceTest.java
@@ -17,6 +17,7 @@ package org.eclipse.pass.metadataschema;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -130,7 +131,67 @@ class SchemaInstanceTest {
 
         SchemaInstance testSchema = new SchemaInstance(map.readTree(example_schema_json));
         SchemaInstance expectedSchema = new SchemaInstance(map.readTree(expected));
-        testSchema.dereference(testSchema.getSchema(), "");
+        //testSchema.dereference(testSchema.getSchema(), "");
+        testSchema.dereference2(testSchema.getSchema(), "");
+        assertEquals(expectedSchema.getSchema(), testSchema.getSchema());
+    }
+
+    @Test
+    void dereferenceTest2() throws Exception {
+        InputStream schemaDerefTest = SchemaInstanceTest.class
+                .getResourceAsStream("/schemas/jhu/schema_to_deref.json");
+
+        InputStream expectedDeref = SchemaInstanceTest.class
+                .getResourceAsStream("/schemas/jhu/schema_to_deref_expected.json");
+
+        SchemaInstance testSchema = new SchemaInstance(map.readTree(schemaDerefTest));
+        SchemaInstance expectedSchema = new SchemaInstance(map.readTree(expectedDeref));
+        //testSchema.dereference(testSchema.getSchema(), "");
+        testSchema.dereference2(testSchema.getSchema(), "");
+        assertEquals(expectedSchema.getSchema(), testSchema.getSchema());
+    }
+
+    @Test
+    void dereferenceArrayObjTest() throws Exception {
+        InputStream schemaDerefTest = SchemaInstanceTest.class
+                .getResourceAsStream("/schemas/jhu/deref_obj_array.json");
+
+        InputStream expectedDeref = SchemaInstanceTest.class
+                .getResourceAsStream("/schemas/jhu/deref_obj_array_expected.json");
+
+        SchemaInstance testSchema = new SchemaInstance(map.readTree(schemaDerefTest));
+        SchemaInstance expectedSchema = new SchemaInstance(map.readTree(expectedDeref));
+        //testSchema.dereference(testSchema.getSchema(), "");
+        testSchema.dereference2(testSchema.getSchema(), "");
+        assertEquals(expectedSchema.getSchema(), testSchema.getSchema());
+    }
+
+    @Test
+    void dereferenceJscholarSimpleTest() throws Exception {
+        InputStream jscholarSchemaJson = SchemaInstanceTest.class
+                .getResourceAsStream("/schemas/jhu/jscholarship_simple.json");
+
+        InputStream jscholarExpected = SchemaInstanceTest.class
+                .getResourceAsStream("/schemas/jhu/jscholarship_simple_deref.json");
+
+        SchemaInstance testSchema = new SchemaInstance(map.readTree(jscholarSchemaJson));
+        SchemaInstance expectedSchema = new SchemaInstance(map.readTree(jscholarExpected));
+        //testSchema.dereference(testSchema.getSchema(), "");
+        testSchema.dereference2(testSchema.getSchema(), "");
+        assertEquals(expectedSchema.getSchema(), testSchema.getSchema());
+    }
+    @Test
+    void dereferenceJscholarTest() throws Exception {
+        InputStream jscholarSchemaJson = SchemaInstanceTest.class
+                .getResourceAsStream("/schemas/jhu/jscholarship.json");
+
+        InputStream jscholarExpected = SchemaInstanceTest.class
+                .getResourceAsStream("/schemas/jhu/jscholarship_deref.json");
+
+        SchemaInstance testSchema = new SchemaInstance(map.readTree(jscholarSchemaJson));
+        SchemaInstance expectedSchema = new SchemaInstance(map.readTree(jscholarExpected));
+        //testSchema.dereference(testSchema.getSchema(), "");
+        testSchema.dereference2(testSchema.getSchema(), "");
         assertEquals(expectedSchema.getSchema(), testSchema.getSchema());
     }
 

--- a/pass-core-metadataschema-service/src/test/java/org/eclipse/pass/metadataschema/SchemaInstanceTest.java
+++ b/pass-core-metadataschema-service/src/test/java/org/eclipse/pass/metadataschema/SchemaInstanceTest.java
@@ -132,7 +132,8 @@ class SchemaInstanceTest {
         SchemaInstance testSchema = new SchemaInstance(map.readTree(example_schema_json));
         SchemaInstance expectedSchema = new SchemaInstance(map.readTree(expected));
         //testSchema.dereference(testSchema.getSchema(), "");
-        testSchema.dereference2(testSchema.getSchema(), "");
+        //testSchema.dereference2(testSchema.getSchema(), "");
+        testSchema.dereference4(testSchema.getSchema());
         assertEquals(expectedSchema.getSchema(), testSchema.getSchema());
     }
 
@@ -147,7 +148,8 @@ class SchemaInstanceTest {
         SchemaInstance testSchema = new SchemaInstance(map.readTree(schemaDerefTest));
         SchemaInstance expectedSchema = new SchemaInstance(map.readTree(expectedDeref));
         //testSchema.dereference(testSchema.getSchema(), "");
-        testSchema.dereference2(testSchema.getSchema(), "");
+        //testSchema.dereference2(testSchema.getSchema(), "");
+        testSchema.dereference4(testSchema.getSchema());
         assertEquals(expectedSchema.getSchema(), testSchema.getSchema());
     }
 
@@ -162,7 +164,8 @@ class SchemaInstanceTest {
         SchemaInstance testSchema = new SchemaInstance(map.readTree(schemaDerefTest));
         SchemaInstance expectedSchema = new SchemaInstance(map.readTree(expectedDeref));
         //testSchema.dereference(testSchema.getSchema(), "");
-        testSchema.dereference2(testSchema.getSchema(), "");
+        //testSchema.dereference2(testSchema.getSchema(), "");
+        testSchema.dereference4(testSchema.getSchema());
         assertEquals(expectedSchema.getSchema(), testSchema.getSchema());
     }
 
@@ -177,7 +180,9 @@ class SchemaInstanceTest {
         SchemaInstance testSchema = new SchemaInstance(map.readTree(jscholarSchemaJson));
         SchemaInstance expectedSchema = new SchemaInstance(map.readTree(jscholarExpected));
         //testSchema.dereference(testSchema.getSchema(), "");
-        testSchema.dereference2(testSchema.getSchema(), "");
+        //testSchema.dereference2(testSchema.getSchema(), "");
+        //testSchema.dereference3(testSchema.getSchema());
+        testSchema.dereference4(testSchema.getSchema());
         assertEquals(expectedSchema.getSchema(), testSchema.getSchema());
     }
     @Test
@@ -191,7 +196,8 @@ class SchemaInstanceTest {
         SchemaInstance testSchema = new SchemaInstance(map.readTree(jscholarSchemaJson));
         SchemaInstance expectedSchema = new SchemaInstance(map.readTree(jscholarExpected));
         //testSchema.dereference(testSchema.getSchema(), "");
-        testSchema.dereference2(testSchema.getSchema(), "");
+        //testSchema.dereference2(testSchema.getSchema(), "");
+        testSchema.dereference4(testSchema.getSchema());
         assertEquals(expectedSchema.getSchema(), testSchema.getSchema());
     }
 

--- a/pass-core-metadataschema-service/src/test/java/org/eclipse/pass/metadataschema/SchemaServiceTest.java
+++ b/pass-core-metadataschema-service/src/test/java/org/eclipse/pass/metadataschema/SchemaServiceTest.java
@@ -246,4 +246,21 @@ class SchemaServiceTest {
         JsonNode result = schemaService.getMergedSchema(repositoryIds);
         assertEquals(expected, result);
     }
+
+    @Test
+    void getMergeJscholarSchemaTest() throws Exception {
+        List<String> repositoryIds = Arrays.asList("1");
+        when(passClientMock.getObject(Repository.class, 1L)).thenReturn(repositoryMock1);
+
+        List<URI> r1_schemas_list = Arrays.asList(new URI("https://example.com/metadata-schemas/jhu/jscholarship.json"));
+
+        when(repositoryMock1.getSchemas()).thenReturn(r1_schemas_list);
+
+        InputStream expected_schema_json = SchemaServiceTest.class
+                .getResourceAsStream("/schemas/jhu/jscholarship_deref.json");
+        ObjectMapper map = new ObjectMapper();
+        JsonNode expected = map.readTree(expected_schema_json);
+        JsonNode result = schemaService.getMergedSchema(repositoryIds);
+        assertEquals(expected, result);
+    }
 }

--- a/pass-core-metadataschema-service/src/test/java/org/eclipse/pass/metadataschema/SchemaServiceTest.java
+++ b/pass-core-metadataschema-service/src/test/java/org/eclipse/pass/metadataschema/SchemaServiceTest.java
@@ -257,7 +257,7 @@ class SchemaServiceTest {
         when(repositoryMock1.getSchemas()).thenReturn(r1_schemas_list);
 
         InputStream expected_schema_json = SchemaServiceTest.class
-                .getResourceAsStream("/schemas/jhu/jscholarship_deref.json");
+                .getResourceAsStream("/schemas/jhu/jscholarship_merge_deref.json");
         ObjectMapper map = new ObjectMapper();
         JsonNode expected = map.readTree(expected_schema_json);
         JsonNode result = schemaService.getMergedSchema(repositoryIds);

--- a/pass-core-metadataschema-service/src/test/resources/schemas/jhu/common.json
+++ b/pass-core-metadataschema-service/src/test/resources/schemas/jhu/common.json
@@ -1,0 +1,55 @@
+{
+    "title": "JHU common schema",
+    "description": "Enumerates the common properties required by most repositories",
+    "$id": "https://eclipse-pass.github.io/pass-metadata-schemas/schemas/jhu/common.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "definitions": {
+        "form": {
+            "type": "object",
+            "title": "Publication Details <br><p class='lead text-muted'>Please provide additional information about your article/manuscript below. If DOI was provided in the initial step of the submission, the metadata associated with that DOI was found and used to prepopulatethis form. </p> <p class='lead text-muted'> <i class='glyphicon glyphicon-info-sign'></i> Fields that are not editable were populated using metadata associated with the provided DOI. </p>",
+            "$comment": "These properties are intended to be displayed in an Alpaca form",
+            "properties": {
+                "title": {
+                    "$ref": "global.json#/properties/title"
+                },
+                "journal-title": {
+                    "$ref": "global.json#/properties/journal-title"
+                },
+                "volume": {
+                    "$ref": "global.json#/properties/volume"
+                },
+                "issue": {
+                    "$ref": "global.json#/properties/issue"
+                },
+                "issns": {
+                    "$ref": "global.json#/properties/issns"
+                },
+                "publisher": {
+                    "$ref": "global.json#/properties/publisher"
+                },
+                "publicationDate": {
+                    "$ref": "global.json#/properties/publicationDate"
+                },
+                "abstract": {
+                    "$ref": "global.json#/properties/abstract"
+                },
+                "authors": {
+                    "$ref": "global.json#/properties/authors"
+                },
+                "under-embargo": {
+                    "$ref": "global.json#/properties/under-embargo"
+                },
+                "Embargo-end-date": {
+                    "$ref": "global.json#/properties/Embargo-end-date"
+                }
+            },
+            "dependencies": {
+                "Embargo-end-date": ["under-embargo"]
+            },
+            "options": {
+                "$ref": "global.json#/options"
+            }
+        }
+    }
+}

--- a/pass-core-metadataschema-service/src/test/resources/schemas/jhu/deref_obj_array.json
+++ b/pass-core-metadataschema-service/src/test/resources/schemas/jhu/deref_obj_array.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://example.org/metadata-schemas/schemas/jhu/deref_obj_array",
+  "$id": "http://example.org/metadata-schemas/schemas/jhu/deref_obj_array",
+  "definitions": {
+    "form": {
+      "type": "string",
+      "title": "Deref this"
+    }
+  },
+  "allOf": [{"$ref": "#/definitions/form"}]
+}

--- a/pass-core-metadataschema-service/src/test/resources/schemas/jhu/deref_obj_array_expected.json
+++ b/pass-core-metadataschema-service/src/test/resources/schemas/jhu/deref_obj_array_expected.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://example.org/metadata-schemas/schemas/jhu/deref_obj_array",
+  "$id": "http://example.org/metadata-schemas/schemas/jhu/deref_obj_array",
+  "definitions": {
+    "form": {
+      "type": "string",
+      "title": "Deref this"
+    }
+  },
+  "allOf": [
+    {
+      "type": "string",
+      "title": "Deref this"
+    }
+  ]
+}

--- a/pass-core-metadataschema-service/src/test/resources/schemas/jhu/example_merged_dereferenced.json
+++ b/pass-core-metadataschema-service/src/test/resources/schemas/jhu/example_merged_dereferenced.json
@@ -22,14 +22,5 @@
 		}
 	},
     "copySchemaName": "http://example.org/metadata-schemas/schemas/jhu/schema_to_dereference",
-    "schema1_title": "X",
-    "schema2_x": {
-      "title": "x",
-      "description": "an awesome letter",
-      "$comment": "displays nicely",
-      "type": "letter"
-    },
-    "schema3_array": ["c", "d", "e"],
-    "schema4_complexarray": ["e", "f", {"g": "h"}],
-    "schema4_hk": ["l", "m", "m'"]
+    "k": ["l", "m", "m'"]
 }

--- a/pass-core-metadataschema-service/src/test/resources/schemas/jhu/expected_jscholarship_common_merge.json
+++ b/pass-core-metadataschema-service/src/test/resources/schemas/jhu/expected_jscholarship_common_merge.json
@@ -2,7 +2,7 @@
   {
     "allOf": [
       {
-        "$id": "https://oa-pass.github.io/metadata-schemas/jhu/global.json",
+        "$id": "https://eclipse-pass.github.io/pass-metadata-schemas/schemas/jhu/global.json",
         "$schema": "http://json-schema.org/draft-07/schema#",
         "additionalProperties": false,
         "dependencies": {
@@ -18,7 +18,7 @@
                 "under-embargo": true
               },
               "fieldClass": "date-time-picker",
-              "helper": "\u003ci\u003eAfter the embargo end date, your submission manuscripts or article can be made public. \u003cb\u003eIf this publication is not under embargo, please leave this field blank.\u003cb\u003e\u003c/i\u003e",
+              "helper": "<i>After the embargo end date, your submission manuscripts or article can be made public. <b>If this publication is not under embargo, please leave this field blank.<b></i>",
               "helpersPosition": "above",
               "inputType": "date",
               "label": "Embargo End Date",
@@ -34,7 +34,7 @@
             "abstract": {
               "fieldClass": "clearfix",
               "hidden": false,
-              "label": "Abstract \u003csmall class=\"text-muted\"\u003e(optional)\u003c/small\u003e",
+              "label": "Abstract <small class=\"text-muted\">(optional)</small>",
               "order": 9,
               "placeholder": "Enter abstract",
               "type": "textarea"
@@ -52,9 +52,9 @@
                     "label": "ORCiD"
                   }
                 },
-                "label": "\u003cspan class=\"d-none\"\u003e\u003c/span\u003e"
+                "label": "<span class=\"d-none\"></span>"
               },
-              "label": "\u003cdiv\u003eAuthors\u003c/div\u003e\u003chr/\u003e",
+              "label": "<div>Authors</div><hr/>",
               "order": 10
             },
             "issns": {
@@ -74,40 +74,40 @@
                     "vertical": false
                   }
                 },
-                "label": "\u003cspan class=\"d-none\"\u003e\u003c/span\u003e"
+                "label": "<span class=\"d-none\"></span>"
               },
-              "label": "\u003cdiv\u003eISSN Information\u003c/div\u003e\u003chr/\u003e",
+              "label": "<div>ISSN Information</div><hr/>",
               "order": 6
             },
             "issue": {
               "hidden": false,
-              "label": "Issue  \u003csmall class=\"text-muted\"\u003e(optional)\u003c/small\u003e",
+              "label": "Issue  <small class=\"text-muted\">(optional)</small>",
               "order": 5,
               "placeholder": "Enter issue",
               "type": "text"
             },
             "journal-NLMTA-ID": {
-              "label": "Journal NLMTA ID \u003csmall class=\"text-muted\"\u003e(optional)\u003c/small\u003e",
+              "label": "Journal NLMTA ID <small class=\"text-muted\">(optional)</small>",
               "order": 3,
               "placeholder": "nlmta",
               "type": "text"
             },
             "journal-title": {
               "hidden": false,
-              "label": "Journal Title \u003csmall class=\"text-muted\"\u003e(required)\u003c/small\u003e",
+              "label": "Journal Title <small class=\"text-muted\">(required)</small>",
               "order": 2,
               "placeholder": "Enter the journal title",
               "type": "text"
             },
             "publicationDate": {
               "hidden": false,
-              "label": "Publication Date  \u003csmall class=\"text-muted\"\u003e(optional)\u003c/small\u003e",
+              "label": "Publication Date  <small class=\"text-muted\">(optional)</small>",
               "order": 8,
               "type": "date"
             },
             "publisher": {
               "hidden": false,
-              "label": "Publisher \u003csmall class=\"text-muted\"\u003e(optional)\u003c/small\u003e",
+              "label": "Publisher <small class=\"text-muted\">(optional)</small>",
               "order": 7,
               "placeholder": "Enter the Publisher",
               "type": "text"
@@ -115,7 +115,7 @@
             "title": {
               "cols": 100,
               "hidden": false,
-              "label": "Article / Manuscript Title \u003csmall class=\"text-muted\"\u003e(required)\u003c/small\u003e",
+              "label": "Article / Manuscript Title <small class=\"text-muted\">(required)</small>",
               "order": 1,
               "placeholder": "Enter the manuscript title",
               "rows": 2,
@@ -130,7 +130,7 @@
             },
             "volume": {
               "hidden": false,
-              "label": "Volume  \u003csmall class=\"text-muted\"\u003e(optional)\u003c/small\u003e",
+              "label": "Volume  <small class=\"text-muted\">(optional)</small>",
               "order": 4,
               "placeholder": "Enter the volume",
               "type": "text"
@@ -333,7 +333,7 @@
         "required": [
           "authors"
         ],
-        "title": "Johns Hopkins - JScholarship \u003cbr\u003e\u003cp class='lead text-muted'\u003eDeposit requirements for JH's institutional repository JScholarship\u003c/p\u003e",
+        "title": "Johns Hopkins - JScholarship <br><p class='lead text-muted'>Deposit requirements for JH's institutional repository JScholarship</p>",
         "type": "object"
       }
     ],
@@ -352,7 +352,7 @@
                 "under-embargo": true
               },
               "fieldClass": "date-time-picker",
-              "helper": "\u003ci\u003eAfter the embargo end date, your submission manuscripts or article can be made public. \u003cb\u003eIf this publication is not under embargo, please leave this field blank.\u003cb\u003e\u003c/i\u003e",
+              "helper": "<i>After the embargo end date, your submission manuscripts or article can be made public. <b>If this publication is not under embargo, please leave this field blank.<b></i>",
               "helpersPosition": "above",
               "inputType": "date",
               "label": "Embargo End Date",
@@ -368,7 +368,7 @@
             "abstract": {
               "fieldClass": "clearfix",
               "hidden": false,
-              "label": "Abstract \u003csmall class=\"text-muted\"\u003e(optional)\u003c/small\u003e",
+              "label": "Abstract <small class=\"text-muted\">(optional)</small>",
               "order": 9,
               "placeholder": "Enter abstract",
               "type": "textarea"
@@ -386,9 +386,9 @@
                     "label": "ORCiD"
                   }
                 },
-                "label": "\u003cspan class=\"d-none\"\u003e\u003c/span\u003e"
+                "label": "<span class=\"d-none\"></span>"
               },
-              "label": "\u003cdiv\u003eAuthors\u003c/div\u003e\u003chr/\u003e",
+              "label": "<div>Authors</div><hr/>",
               "order": 10
             },
             "issns": {
@@ -408,40 +408,40 @@
                     "vertical": false
                   }
                 },
-                "label": "\u003cspan class=\"d-none\"\u003e\u003c/span\u003e"
+                "label": "<span class=\"d-none\"></span>"
               },
-              "label": "\u003cdiv\u003eISSN Information\u003c/div\u003e\u003chr/\u003e",
+              "label": "<div>ISSN Information</div><hr/>",
               "order": 6
             },
             "issue": {
               "hidden": false,
-              "label": "Issue  \u003csmall class=\"text-muted\"\u003e(optional)\u003c/small\u003e",
+              "label": "Issue  <small class=\"text-muted\">(optional)</small>",
               "order": 5,
               "placeholder": "Enter issue",
               "type": "text"
             },
             "journal-NLMTA-ID": {
-              "label": "Journal NLMTA ID \u003csmall class=\"text-muted\"\u003e(optional)\u003c/small\u003e",
+              "label": "Journal NLMTA ID <small class=\"text-muted\">(optional)</small>",
               "order": 3,
               "placeholder": "nlmta",
               "type": "text"
             },
             "journal-title": {
               "hidden": false,
-              "label": "Journal Title \u003csmall class=\"text-muted\"\u003e(required)\u003c/small\u003e",
+              "label": "Journal Title <small class=\"text-muted\">(required)</small>",
               "order": 2,
               "placeholder": "Enter the journal title",
               "type": "text"
             },
             "publicationDate": {
               "hidden": false,
-              "label": "Publication Date  \u003csmall class=\"text-muted\"\u003e(optional)\u003c/small\u003e",
+              "label": "Publication Date  <small class=\"text-muted\">(optional)</small>",
               "order": 8,
               "type": "date"
             },
             "publisher": {
               "hidden": false,
-              "label": "Publisher \u003csmall class=\"text-muted\"\u003e(optional)\u003c/small\u003e",
+              "label": "Publisher <small class=\"text-muted\">(optional)</small>",
               "order": 7,
               "placeholder": "Enter the Publisher",
               "type": "text"
@@ -449,7 +449,7 @@
             "title": {
               "cols": 100,
               "hidden": false,
-              "label": "Article / Manuscript Title \u003csmall class=\"text-muted\"\u003e(required)\u003c/small\u003e",
+              "label": "Article / Manuscript Title <small class=\"text-muted\">(required)</small>",
               "order": 1,
               "placeholder": "Enter the manuscript title",
               "rows": 2,
@@ -464,7 +464,7 @@
             },
             "volume": {
               "hidden": false,
-              "label": "Volume  \u003csmall class=\"text-muted\"\u003e(optional)\u003c/small\u003e",
+              "label": "Volume  <small class=\"text-muted\">(optional)</small>",
               "order": 4,
               "placeholder": "Enter the volume",
               "type": "text"
@@ -569,7 +569,7 @@
         "required": [
           "authors"
         ],
-        "title": "Johns Hopkins - JScholarship \u003cbr\u003e\u003cp class='lead text-muted'\u003eDeposit requirements for JH's institutional repository JScholarship\u003c/p\u003e",
+        "title": "Johns Hopkins - JScholarship <br><p class='lead text-muted'>Deposit requirements for JH's institutional repository JScholarship</p>",
         "type": "object"
       },
       "options": {
@@ -579,7 +579,7 @@
               "under-embargo": true
             },
             "fieldClass": "date-time-picker",
-            "helper": "\u003ci\u003eAfter the embargo end date, your submission manuscripts or article can be made public. \u003cb\u003eIf this publication is not under embargo, please leave this field blank.\u003cb\u003e\u003c/i\u003e",
+            "helper": "<i>After the embargo end date, your submission manuscripts or article can be made public. <b>If this publication is not under embargo, please leave this field blank.<b></i>",
             "helpersPosition": "above",
             "inputType": "date",
             "label": "Embargo End Date",
@@ -595,7 +595,7 @@
           "abstract": {
             "fieldClass": "clearfix",
             "hidden": false,
-            "label": "Abstract \u003csmall class=\"text-muted\"\u003e(optional)\u003c/small\u003e",
+            "label": "Abstract <small class=\"text-muted\">(optional)</small>",
             "order": 9,
             "placeholder": "Enter abstract",
             "type": "textarea"
@@ -613,9 +613,9 @@
                   "label": "ORCiD"
                 }
               },
-              "label": "\u003cspan class=\"d-none\"\u003e\u003c/span\u003e"
+              "label": "<span class=\"d-none\"></span>"
             },
-            "label": "\u003cdiv\u003eAuthors\u003c/div\u003e\u003chr/\u003e",
+            "label": "<div>Authors</div><hr/>",
             "order": 10
           },
           "issns": {
@@ -635,40 +635,40 @@
                   "vertical": false
                 }
               },
-              "label": "\u003cspan class=\"d-none\"\u003e\u003c/span\u003e"
+              "label": "<span class=\"d-none\"></span>"
             },
-            "label": "\u003cdiv\u003eISSN Information\u003c/div\u003e\u003chr/\u003e",
+            "label": "<div>ISSN Information</div><hr/>",
             "order": 6
           },
           "issue": {
             "hidden": false,
-            "label": "Issue  \u003csmall class=\"text-muted\"\u003e(optional)\u003c/small\u003e",
+            "label": "Issue  <small class=\"text-muted\">(optional)</small>",
             "order": 5,
             "placeholder": "Enter issue",
             "type": "text"
           },
           "journal-NLMTA-ID": {
-            "label": "Journal NLMTA ID \u003csmall class=\"text-muted\"\u003e(optional)\u003c/small\u003e",
+            "label": "Journal NLMTA ID <small class=\"text-muted\">(optional)</small>",
             "order": 3,
             "placeholder": "nlmta",
             "type": "text"
           },
           "journal-title": {
             "hidden": false,
-            "label": "Journal Title \u003csmall class=\"text-muted\"\u003e(required)\u003c/small\u003e",
+            "label": "Journal Title <small class=\"text-muted\">(required)</small>",
             "order": 2,
             "placeholder": "Enter the journal title",
             "type": "text"
           },
           "publicationDate": {
             "hidden": false,
-            "label": "Publication Date  \u003csmall class=\"text-muted\"\u003e(optional)\u003c/small\u003e",
+            "label": "Publication Date  <small class=\"text-muted\">(optional)</small>",
             "order": 8,
             "type": "date"
           },
           "publisher": {
             "hidden": false,
-            "label": "Publisher \u003csmall class=\"text-muted\"\u003e(optional)\u003c/small\u003e",
+            "label": "Publisher <small class=\"text-muted\">(optional)</small>",
             "order": 7,
             "placeholder": "Enter the Publisher",
             "type": "text"
@@ -676,7 +676,7 @@
           "title": {
             "cols": 100,
             "hidden": false,
-            "label": "Article / Manuscript Title \u003csmall class=\"text-muted\"\u003e(required)\u003c/small\u003e",
+            "label": "Article / Manuscript Title <small class=\"text-muted\">(required)</small>",
             "order": 1,
             "placeholder": "Enter the manuscript title",
             "rows": 2,
@@ -691,7 +691,7 @@
           },
           "volume": {
             "hidden": false,
-            "label": "Volume  \u003csmall class=\"text-muted\"\u003e(optional)\u003c/small\u003e",
+            "label": "Volume  <small class=\"text-muted\">(optional)</small>",
             "order": 4,
             "placeholder": "Enter the volume",
             "type": "text"

--- a/pass-core-metadataschema-service/src/test/resources/schemas/jhu/expected_jscholarship_common_merge.json
+++ b/pass-core-metadataschema-service/src/test/resources/schemas/jhu/expected_jscholarship_common_merge.json
@@ -1,0 +1,704 @@
+[
+  {
+    "allOf": [
+      {
+        "$id": "https://oa-pass.github.io/metadata-schemas/jhu/global.json",
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "dependencies": {
+          "Embargo-end-date": [
+            "under-embargo"
+          ]
+        },
+        "description": "Defines all possible metadata fields for PASS deposit",
+        "options": {
+          "fields": {
+            "Embargo-end-date": {
+              "dependencies": {
+                "under-embargo": true
+              },
+              "fieldClass": "date-time-picker",
+              "helper": "\u003ci\u003eAfter the embargo end date, your submission manuscripts or article can be made public. \u003cb\u003eIf this publication is not under embargo, please leave this field blank.\u003cb\u003e\u003c/i\u003e",
+              "helpersPosition": "above",
+              "inputType": "date",
+              "label": "Embargo End Date",
+              "order": 12,
+              "picker": {
+                "allowInputToggle": true,
+                "format": "MM/DD/YY"
+              },
+              "placeholder": "dd/mm/yyyy",
+              "type": "date",
+              "validate": true
+            },
+            "abstract": {
+              "fieldClass": "clearfix",
+              "hidden": false,
+              "label": "Abstract \u003csmall class=\"text-muted\"\u003e(optional)\u003c/small\u003e",
+              "order": 9,
+              "placeholder": "Enter abstract",
+              "type": "textarea"
+            },
+            "authors": {
+              "hidden": false,
+              "items": {
+                "fields": {
+                  "author": {
+                    "fieldClass": "body-text col-6 pull-left pl-0",
+                    "label": "Name"
+                  },
+                  "orcid": {
+                    "fieldClass": "body-text col-6 pull-left pr-0",
+                    "label": "ORCiD"
+                  }
+                },
+                "label": "\u003cspan class=\"d-none\"\u003e\u003c/span\u003e"
+              },
+              "label": "\u003cdiv\u003eAuthors\u003c/div\u003e\u003chr/\u003e",
+              "order": 10
+            },
+            "issns": {
+              "fieldClass": "",
+              "hidden": false,
+              "items": {
+                "fieldClass": "row",
+                "fields": {
+                  "issn": {
+                    "fieldClass": "body-text col-6 pull-left ",
+                    "label": "ISSN"
+                  },
+                  "pubType": {
+                    "fieldClass": "body-text col-6 pull-left md-pubtype",
+                    "label": "Publication Type",
+                    "removeDefaultNone": true,
+                    "vertical": false
+                  }
+                },
+                "label": "\u003cspan class=\"d-none\"\u003e\u003c/span\u003e"
+              },
+              "label": "\u003cdiv\u003eISSN Information\u003c/div\u003e\u003chr/\u003e",
+              "order": 6
+            },
+            "issue": {
+              "hidden": false,
+              "label": "Issue  \u003csmall class=\"text-muted\"\u003e(optional)\u003c/small\u003e",
+              "order": 5,
+              "placeholder": "Enter issue",
+              "type": "text"
+            },
+            "journal-NLMTA-ID": {
+              "label": "Journal NLMTA ID \u003csmall class=\"text-muted\"\u003e(optional)\u003c/small\u003e",
+              "order": 3,
+              "placeholder": "nlmta",
+              "type": "text"
+            },
+            "journal-title": {
+              "hidden": false,
+              "label": "Journal Title \u003csmall class=\"text-muted\"\u003e(required)\u003c/small\u003e",
+              "order": 2,
+              "placeholder": "Enter the journal title",
+              "type": "text"
+            },
+            "publicationDate": {
+              "hidden": false,
+              "label": "Publication Date  \u003csmall class=\"text-muted\"\u003e(optional)\u003c/small\u003e",
+              "order": 8,
+              "type": "date"
+            },
+            "publisher": {
+              "hidden": false,
+              "label": "Publisher \u003csmall class=\"text-muted\"\u003e(optional)\u003c/small\u003e",
+              "order": 7,
+              "placeholder": "Enter the Publisher",
+              "type": "text"
+            },
+            "title": {
+              "cols": 100,
+              "hidden": false,
+              "label": "Article / Manuscript Title \u003csmall class=\"text-muted\"\u003e(required)\u003c/small\u003e",
+              "order": 1,
+              "placeholder": "Enter the manuscript title",
+              "rows": 2,
+              "type": "textarea"
+            },
+            "under-embargo": {
+              "fieldClass": "m-0 mt-4",
+              "hidden": false,
+              "order": 11,
+              "rightLabel": "The material being submitted is published under an embargo.",
+              "type": "checkbox"
+            },
+            "volume": {
+              "hidden": false,
+              "label": "Volume  \u003csmall class=\"text-muted\"\u003e(optional)\u003c/small\u003e",
+              "order": 4,
+              "placeholder": "Enter the volume",
+              "type": "text"
+            }
+          }
+        },
+        "properties": {
+          "$schema": {
+            "description": "The JSON schema that applies to the resulting metadata blob",
+            "title": "JSON schema",
+            "type": "string"
+          },
+          "Embargo-end-date": {
+            "description": "Date at which the article or manuscript may be made public",
+            "format": "date",
+            "title": "Embargo end date",
+            "type": "string"
+          },
+          "abstract": {
+            "description": "The abstract of the article or manuscript being submitted",
+            "title": "Abstract",
+            "type": "string"
+          },
+          "agent_information": {
+            "description": "Contains the identity and version of the user's browser",
+            "properties": {
+              "name": {
+                "title": "User agent (browser) name",
+                "type": "string"
+              },
+              "version": {
+                "title": "User agent (browser) version",
+                "type": "string"
+              }
+            },
+            "title": "User agent (browser) information",
+            "type": "object"
+          },
+          "agreements": {
+            "$comment": "This was formerly known as 'embargo', available only for JScholarship metadata",
+            "description": "Maps repository keys to the text or links containing the agreements accepted by the submitter",
+            "patternProperties": {
+              "^.+$": {
+                "$comment": "Example: {'jScholarship': 'http://example.org/agreementText'}",
+                "description": "Text or link agreed to for the given repository key",
+                "title": "Agreement",
+                "type": "string"
+              }
+            },
+            "title": "Agreements to deposit conditions",
+            "type": "object"
+          },
+          "authors": {
+            "description": "List of authors and their associated ORCIDS, if available",
+            "items": {
+              "properties": {
+                "author": {
+                  "type": "string"
+                },
+                "orcid": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "author"
+              ],
+              "title": "Author",
+              "type": "object"
+            },
+            "title": "Authors of this article or manuscript",
+            "type": "array",
+            "uniqueItems": true
+          },
+          "doi": {
+            "description": "The DOI of the individual article or manuscript submitted",
+            "pattern": "^10\\..+?/.+?$",
+            "title": "DOI of article",
+            "type": "string"
+          },
+          "hints": {
+            "additionalProperties": false,
+            "description": "Hints have semantics shared by the UI and the backend that are intended to influence the backend processing of the submission.",
+            "properties": {
+              "collection-tags": {
+                "items": {
+                  "type": "string"
+                },
+                "title": "Tags impacting the collection used by Deposit Services for deposit",
+                "type": "array",
+                "uniqueItems": true
+              }
+            },
+            "title": "Hints provided by the UI to backend services",
+            "type": "object"
+          },
+          "issns": {
+            "description": "List of ISSN numbers with optional publication type",
+            "items": {
+              "properties": {
+                "issn": {
+                  "title": "ISSN ",
+                  "type": "string"
+                },
+                "pubType": {
+                  "enum": [
+                    "Print",
+                    "Online"
+                  ],
+                  "title": "publication type",
+                  "type": "string"
+                }
+              },
+              "title": "ISSN info",
+              "type": "object"
+            },
+            "title": "ISSN information for the manuscript's journal",
+            "type": "array",
+            "uniqueItems": true
+          },
+          "issue": {
+            "description": "Issue number of the journal this article or manuscript was submitted to",
+            "title": "Journal issue",
+            "type": "string"
+          },
+          "journal-NLMTA-ID": {
+            "description": "NLM identifier for a journal",
+            "title": "NTMLA",
+            "type": "string"
+          },
+          "journal-title": {
+            "description": "Title of the journal the individual article or manuscript was submitted to",
+            "title": "Journal title",
+            "type": "string"
+          },
+          "journal-title-short": {
+            "description": "Short journal title from CrossRef",
+            "title": "Short journal title",
+            "type": "string"
+          },
+          "publicationDate": {
+            "$comment": "This was formerly date-time format, but that appears too precise for values like 'Summer 2018'",
+            "description": "Publication date of the journal or article this manuscript was submitted to",
+            "title": "Publication Date",
+            "type": "string"
+          },
+          "publisher": {
+            "description": "Publisher of the journal this article or manuscript was submitted to",
+            "title": "Publisher",
+            "type": "string"
+          },
+          "title": {
+            "description": "The title of the individual article or manuscript that was submitted",
+            "title": "Article / Manuscript Title",
+            "type": "string"
+          },
+          "under-embargo": {
+            "$comment": "This should probably be a boolean",
+            "description": "Indicates wither the article or manuscript is under embargo",
+            "title": "Under Embargo",
+            "type": "string"
+          },
+          "volume": {
+            "description": "journal volume this article or manuscript was published in",
+            "title": "Journal Volume",
+            "type": "string"
+          }
+        },
+        "required": [
+          "$schema",
+          "title",
+          "journal-title"
+        ],
+        "title": "JHU global schema",
+        "type": "object"
+      },
+      {
+        "properties": {
+          "authors": {
+            "description": "List of authors and their associated ORCIDS, if available",
+            "items": {
+              "properties": {
+                "author": {
+                  "type": "string"
+                },
+                "orcid": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "author"
+              ],
+              "title": "Author",
+              "type": "object"
+            },
+            "title": "Authors of this article or manuscript",
+            "type": "array",
+            "uniqueItems": true
+          }
+        },
+        "required": [
+          "authors"
+        ],
+        "title": "Johns Hopkins - JScholarship \u003cbr\u003e\u003cp class='lead text-muted'\u003eDeposit requirements for JH's institutional repository JScholarship\u003c/p\u003e",
+        "type": "object"
+      }
+    ],
+    "definitions": {
+      "form": {
+        "$comment": "These properties are intended to be displayed in an Alpaca form",
+        "dependencies": {
+          "Embargo-end-date": [
+            "under-embargo"
+          ]
+        },
+        "options": {
+          "fields": {
+            "Embargo-end-date": {
+              "dependencies": {
+                "under-embargo": true
+              },
+              "fieldClass": "date-time-picker",
+              "helper": "\u003ci\u003eAfter the embargo end date, your submission manuscripts or article can be made public. \u003cb\u003eIf this publication is not under embargo, please leave this field blank.\u003cb\u003e\u003c/i\u003e",
+              "helpersPosition": "above",
+              "inputType": "date",
+              "label": "Embargo End Date",
+              "order": 12,
+              "picker": {
+                "allowInputToggle": true,
+                "format": "MM/DD/YY"
+              },
+              "placeholder": "dd/mm/yyyy",
+              "type": "date",
+              "validate": true
+            },
+            "abstract": {
+              "fieldClass": "clearfix",
+              "hidden": false,
+              "label": "Abstract \u003csmall class=\"text-muted\"\u003e(optional)\u003c/small\u003e",
+              "order": 9,
+              "placeholder": "Enter abstract",
+              "type": "textarea"
+            },
+            "authors": {
+              "hidden": false,
+              "items": {
+                "fields": {
+                  "author": {
+                    "fieldClass": "body-text col-6 pull-left pl-0",
+                    "label": "Name"
+                  },
+                  "orcid": {
+                    "fieldClass": "body-text col-6 pull-left pr-0",
+                    "label": "ORCiD"
+                  }
+                },
+                "label": "\u003cspan class=\"d-none\"\u003e\u003c/span\u003e"
+              },
+              "label": "\u003cdiv\u003eAuthors\u003c/div\u003e\u003chr/\u003e",
+              "order": 10
+            },
+            "issns": {
+              "fieldClass": "",
+              "hidden": false,
+              "items": {
+                "fieldClass": "row",
+                "fields": {
+                  "issn": {
+                    "fieldClass": "body-text col-6 pull-left ",
+                    "label": "ISSN"
+                  },
+                  "pubType": {
+                    "fieldClass": "body-text col-6 pull-left md-pubtype",
+                    "label": "Publication Type",
+                    "removeDefaultNone": true,
+                    "vertical": false
+                  }
+                },
+                "label": "\u003cspan class=\"d-none\"\u003e\u003c/span\u003e"
+              },
+              "label": "\u003cdiv\u003eISSN Information\u003c/div\u003e\u003chr/\u003e",
+              "order": 6
+            },
+            "issue": {
+              "hidden": false,
+              "label": "Issue  \u003csmall class=\"text-muted\"\u003e(optional)\u003c/small\u003e",
+              "order": 5,
+              "placeholder": "Enter issue",
+              "type": "text"
+            },
+            "journal-NLMTA-ID": {
+              "label": "Journal NLMTA ID \u003csmall class=\"text-muted\"\u003e(optional)\u003c/small\u003e",
+              "order": 3,
+              "placeholder": "nlmta",
+              "type": "text"
+            },
+            "journal-title": {
+              "hidden": false,
+              "label": "Journal Title \u003csmall class=\"text-muted\"\u003e(required)\u003c/small\u003e",
+              "order": 2,
+              "placeholder": "Enter the journal title",
+              "type": "text"
+            },
+            "publicationDate": {
+              "hidden": false,
+              "label": "Publication Date  \u003csmall class=\"text-muted\"\u003e(optional)\u003c/small\u003e",
+              "order": 8,
+              "type": "date"
+            },
+            "publisher": {
+              "hidden": false,
+              "label": "Publisher \u003csmall class=\"text-muted\"\u003e(optional)\u003c/small\u003e",
+              "order": 7,
+              "placeholder": "Enter the Publisher",
+              "type": "text"
+            },
+            "title": {
+              "cols": 100,
+              "hidden": false,
+              "label": "Article / Manuscript Title \u003csmall class=\"text-muted\"\u003e(required)\u003c/small\u003e",
+              "order": 1,
+              "placeholder": "Enter the manuscript title",
+              "rows": 2,
+              "type": "textarea"
+            },
+            "under-embargo": {
+              "fieldClass": "m-0 mt-4",
+              "hidden": false,
+              "order": 11,
+              "rightLabel": "The material being submitted is published under an embargo.",
+              "type": "checkbox"
+            },
+            "volume": {
+              "hidden": false,
+              "label": "Volume  \u003csmall class=\"text-muted\"\u003e(optional)\u003c/small\u003e",
+              "order": 4,
+              "placeholder": "Enter the volume",
+              "type": "text"
+            }
+          }
+        },
+        "properties": {
+          "Embargo-end-date": {
+            "description": "Date at which the article or manuscript may be made public",
+            "format": "date",
+            "title": "Embargo end date",
+            "type": "string"
+          },
+          "abstract": {
+            "description": "The abstract of the article or manuscript being submitted",
+            "title": "Abstract",
+            "type": "string"
+          },
+          "authors": {
+            "description": "List of authors and their associated ORCIDS, if available",
+            "items": {
+              "properties": {
+                "author": {
+                  "type": "string"
+                },
+                "orcid": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "author"
+              ],
+              "title": "Author",
+              "type": "object"
+            },
+            "title": "Authors of this article or manuscript",
+            "type": "array",
+            "uniqueItems": true
+          },
+          "issns": {
+            "description": "List of ISSN numbers with optional publication type",
+            "items": {
+              "properties": {
+                "issn": {
+                  "title": "ISSN ",
+                  "type": "string"
+                },
+                "pubType": {
+                  "enum": [
+                    "Print",
+                    "Online"
+                  ],
+                  "title": "publication type",
+                  "type": "string"
+                }
+              },
+              "title": "ISSN info",
+              "type": "object"
+            },
+            "title": "ISSN information for the manuscript's journal",
+            "type": "array",
+            "uniqueItems": true
+          },
+          "issue": {
+            "description": "Issue number of the journal this article or manuscript was submitted to",
+            "title": "Journal issue",
+            "type": "string"
+          },
+          "journal-title": {
+            "description": "Title of the journal the individual article or manuscript was submitted to",
+            "title": "Journal title",
+            "type": "string"
+          },
+          "publicationDate": {
+            "$comment": "This was formerly date-time format, but that appears too precise for values like 'Summer 2018'",
+            "description": "Publication date of the journal or article this manuscript was submitted to",
+            "title": "Publication Date",
+            "type": "string"
+          },
+          "publisher": {
+            "description": "Publisher of the journal this article or manuscript was submitted to",
+            "title": "Publisher",
+            "type": "string"
+          },
+          "title": {
+            "description": "The title of the individual article or manuscript that was submitted",
+            "title": "Article / Manuscript Title",
+            "type": "string"
+          },
+          "under-embargo": {
+            "$comment": "This should probably be a boolean",
+            "description": "Indicates wither the article or manuscript is under embargo",
+            "title": "Under Embargo",
+            "type": "string"
+          },
+          "volume": {
+            "description": "journal volume this article or manuscript was published in",
+            "title": "Journal Volume",
+            "type": "string"
+          }
+        },
+        "required": [
+          "authors"
+        ],
+        "title": "Johns Hopkins - JScholarship \u003cbr\u003e\u003cp class='lead text-muted'\u003eDeposit requirements for JH's institutional repository JScholarship\u003c/p\u003e",
+        "type": "object"
+      },
+      "options": {
+        "fields": {
+          "Embargo-end-date": {
+            "dependencies": {
+              "under-embargo": true
+            },
+            "fieldClass": "date-time-picker",
+            "helper": "\u003ci\u003eAfter the embargo end date, your submission manuscripts or article can be made public. \u003cb\u003eIf this publication is not under embargo, please leave this field blank.\u003cb\u003e\u003c/i\u003e",
+            "helpersPosition": "above",
+            "inputType": "date",
+            "label": "Embargo End Date",
+            "order": 12,
+            "picker": {
+              "allowInputToggle": true,
+              "format": "MM/DD/YY"
+            },
+            "placeholder": "dd/mm/yyyy",
+            "type": "date",
+            "validate": true
+          },
+          "abstract": {
+            "fieldClass": "clearfix",
+            "hidden": false,
+            "label": "Abstract \u003csmall class=\"text-muted\"\u003e(optional)\u003c/small\u003e",
+            "order": 9,
+            "placeholder": "Enter abstract",
+            "type": "textarea"
+          },
+          "authors": {
+            "hidden": false,
+            "items": {
+              "fields": {
+                "author": {
+                  "fieldClass": "body-text col-6 pull-left pl-0",
+                  "label": "Name"
+                },
+                "orcid": {
+                  "fieldClass": "body-text col-6 pull-left pr-0",
+                  "label": "ORCiD"
+                }
+              },
+              "label": "\u003cspan class=\"d-none\"\u003e\u003c/span\u003e"
+            },
+            "label": "\u003cdiv\u003eAuthors\u003c/div\u003e\u003chr/\u003e",
+            "order": 10
+          },
+          "issns": {
+            "fieldClass": "",
+            "hidden": false,
+            "items": {
+              "fieldClass": "row",
+              "fields": {
+                "issn": {
+                  "fieldClass": "body-text col-6 pull-left ",
+                  "label": "ISSN"
+                },
+                "pubType": {
+                  "fieldClass": "body-text col-6 pull-left md-pubtype",
+                  "label": "Publication Type",
+                  "removeDefaultNone": true,
+                  "vertical": false
+                }
+              },
+              "label": "\u003cspan class=\"d-none\"\u003e\u003c/span\u003e"
+            },
+            "label": "\u003cdiv\u003eISSN Information\u003c/div\u003e\u003chr/\u003e",
+            "order": 6
+          },
+          "issue": {
+            "hidden": false,
+            "label": "Issue  \u003csmall class=\"text-muted\"\u003e(optional)\u003c/small\u003e",
+            "order": 5,
+            "placeholder": "Enter issue",
+            "type": "text"
+          },
+          "journal-NLMTA-ID": {
+            "label": "Journal NLMTA ID \u003csmall class=\"text-muted\"\u003e(optional)\u003c/small\u003e",
+            "order": 3,
+            "placeholder": "nlmta",
+            "type": "text"
+          },
+          "journal-title": {
+            "hidden": false,
+            "label": "Journal Title \u003csmall class=\"text-muted\"\u003e(required)\u003c/small\u003e",
+            "order": 2,
+            "placeholder": "Enter the journal title",
+            "type": "text"
+          },
+          "publicationDate": {
+            "hidden": false,
+            "label": "Publication Date  \u003csmall class=\"text-muted\"\u003e(optional)\u003c/small\u003e",
+            "order": 8,
+            "type": "date"
+          },
+          "publisher": {
+            "hidden": false,
+            "label": "Publisher \u003csmall class=\"text-muted\"\u003e(optional)\u003c/small\u003e",
+            "order": 7,
+            "placeholder": "Enter the Publisher",
+            "type": "text"
+          },
+          "title": {
+            "cols": 100,
+            "hidden": false,
+            "label": "Article / Manuscript Title \u003csmall class=\"text-muted\"\u003e(required)\u003c/small\u003e",
+            "order": 1,
+            "placeholder": "Enter the manuscript title",
+            "rows": 2,
+            "type": "textarea"
+          },
+          "under-embargo": {
+            "fieldClass": "m-0 mt-4",
+            "hidden": false,
+            "order": 11,
+            "rightLabel": "The material being submitted is published under an embargo.",
+            "type": "checkbox"
+          },
+          "volume": {
+            "hidden": false,
+            "label": "Volume  \u003csmall class=\"text-muted\"\u003e(optional)\u003c/small\u003e",
+            "order": 4,
+            "placeholder": "Enter the volume",
+            "type": "text"
+          }
+        }
+      }
+    },
+    "type": "object"
+  }
+]

--- a/pass-core-metadataschema-service/src/test/resources/schemas/jhu/global.json
+++ b/pass-core-metadataschema-service/src/test/resources/schemas/jhu/global.json
@@ -1,0 +1,298 @@
+{
+    "title": "JHU global schema",
+    "description": "Defines all possible metadata fields for PASS deposit",
+    "$id": "https://eclipse-pass.github.io/pass-metadata-schemas/schemas/jhu/global.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "required": [
+        "$schema",
+        "title",
+        "journal-title"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "$schema": {
+            "type": "string",
+            "title": "JSON schema",
+            "description": "The JSON schema that applies to the resulting metadata blob"
+        },
+        "agreements": {
+            "type": "object",
+            "title": "Agreements to deposit conditions",
+            "description": "Maps repository keys to the text or links containing the agreements accepted by the submitter",
+            "$comment": "This was formerly known as 'embargo', available only for JScholarship metadata",
+            "patternProperties": {
+                "^.+$": {
+                    "type": "string",
+                    "title": "Agreement",
+                    "description": "Text or link agreed to for the given repository key",
+                    "$comment": "Example: {'jScholarship': 'http://example.org/agreementText'}"
+                }
+            }
+        },
+        "abstract": {
+            "type": "string",
+            "title": "Abstract",
+            "description": "The abstract of the article or manuscript being submitted"
+        },
+        "agent_information": {
+            "type": "object",
+            "title": "User agent (browser) information",
+            "description": "Contains the identity and version of the user's browser",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "title": "User agent (browser) name"
+                },
+                "version": {
+                    "type": "string",
+                    "title": "User agent (browser) version"
+                }
+            }
+        },
+        "authors": {
+            "type": "array",
+            "title": "Authors of this article or manuscript",
+            "description": "List of authors and their associated ORCIDS, if available",
+            "uniqueItems": true,
+            "items": {
+                "type": "object",
+                "title": "Author",
+                "properties": {
+                    "author": {
+                        "type": "string"
+                    },
+                    "orcid": {
+                        "type": "string"
+                    }
+                },
+                "required": ["author"]
+            }
+        },
+        "doi": {
+            "type": "string",
+            "pattern": "^10\\..+?/.+?$",
+            "title": "DOI of article",
+            "description": "The DOI of the individual article or manuscript submitted"
+        },
+        "Embargo-end-date": {
+            "type": "string",
+            "format": "date",
+            "title": "Embargo end date",
+            "description": "Date at which the article or manuscript may be made public"
+        },
+        "hints": {
+            "type": "object",
+            "title": "Hints provided by the UI to backend services",
+            "description": "Hints have semantics shared by the UI and the backend that are intended to influence the backend processing of the submission.",
+            "additionalProperties": false,
+            "properties": {
+                "collection-tags": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "title": "Tags impacting the collection used by Deposit Services for deposit",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "journal-NLMTA-ID": {
+            "type": "string",
+            "title": "NTMLA",
+            "description": "NLM identifier for a journal"
+        },
+        "journal-title": {
+            "type": "string",
+            "title": "Journal title",
+            "description": "Title of the journal the individual article or manuscript was submitted to"
+        },
+        "journal-title-short": {
+            "type": "string",
+            "title": "Short journal title",
+            "description": "Short journal title from CrossRef"
+        },
+        "issue": {
+            "type": "string",
+            "title": "Journal issue",
+            "description": "Issue number of the journal this article or manuscript was submitted to"
+        },
+        "issns": {
+            "type": "array",
+            "title": "ISSN information for the manuscript's journal",
+            "description": "List of ISSN numbers with optional publication type",
+            "uniqueItems": true,
+            "items": {
+                "type": "object",
+                "title": "ISSN info",
+                "properties": {
+                    "issn": {
+                        "type": "string",
+                        "title": "ISSN "
+                    },
+                    "pubType": {
+                        "type": "string",
+                        "title": "publication type",
+                        "enum": ["Print", "Online"]
+                    }
+                }
+            }
+        },
+        "publisher": {
+            "type": "string",
+            "title": "Publisher",
+            "description": "Publisher of the journal this article or manuscript was submitted to"
+        },
+        "publicationDate": {
+            "type": "string",
+            "title": "Publication Date",
+            "description": "Publication date of the journal or article this manuscript was submitted to",
+            "$comment": "This was formerly date-time format, but that appears too precise for values like 'Summer 2018'"
+        },
+        "title": {
+            "type": "string",
+            "title": "Article / Manuscript Title",
+            "description": "The title of the individual article or manuscript that was submitted"
+        },
+        "under-embargo": {
+            "type": "string",
+            "title": "Under Embargo",
+            "description": "Indicates wither the article or manuscript is under embargo",
+            "$comment": "This should probably be a boolean"
+        },
+        "volume": {
+            "type": "string",
+            "title": "Journal Volume",
+            "description": "journal volume this article or manuscript was published in"
+        }
+    },
+    "dependencies": {
+        "Embargo-end-date": ["under-embargo"]
+    },
+    "options": {
+        "fields": {
+            "title": {
+                "type": "textarea",
+                "label": "Article / Manuscript Title <small class=\"text-muted\">(required)</small>",
+                "placeholder": "Enter the manuscript title",
+                "rows": 2,
+                "cols": 100,
+                "hidden": false,
+                "order": 1
+            },
+            "journal-title": {
+                "type": "text",
+                "label": "Journal Title <small class=\"text-muted\">(required)</small>",
+                "placeholder": "Enter the journal title",
+                "hidden": false,
+                "order": 2
+            },
+            "journal-NLMTA-ID": {
+                "type": "text",
+                "label": "Journal NLMTA ID <small class=\"text-muted\">(optional)</small>",
+                "placeholder": "nlmta",
+                "order": 3
+            },
+            "volume": {
+                "type": "text",
+                "label": "Volume  <small class=\"text-muted\">(optional)</small>",
+                "placeholder": "Enter the volume",
+                "hidden": false,
+                "order": 4
+            },
+            "issue": {
+                "type": "text",
+                "label": "Issue  <small class=\"text-muted\">(optional)</small>",
+                "placeholder": "Enter issue",
+                "hidden": false,
+                "order": 5
+            },
+            "issns": {
+                "label": "<div>ISSN Information</div><hr/>",
+                "hidden": false,
+                "fieldClass": "",
+                "items": {
+                    "label": "<span class=\"d-none\"></span>",
+                    "fieldClass": "row",
+                    "fields": {
+                        "issn": {
+                            "label": "ISSN",
+                            "fieldClass": "body-text col-6 pull-left "
+                        },
+                        "pubType": {
+                            "label": "Publication Type",
+                            "fieldClass": "body-text col-6 pull-left md-pubtype",
+                            "vertical": false,
+                            "removeDefaultNone": true
+                        }
+                    }
+                },
+                "order": 6
+            },
+            "publisher": {
+                "type": "text",
+                "label": "Publisher <small class=\"text-muted\">(optional)</small>",
+                "placeholder": "Enter the Publisher",
+                "hidden": false,
+                "order": 7
+            },
+            "publicationDate": {
+                "type": "date",
+                "label": "Publication Date  <small class=\"text-muted\">(optional)</small>",
+                "hidden": false,
+                "order": 8
+            },
+            "abstract": {
+                "type": "textarea",
+                "label": "Abstract <small class=\"text-muted\">(optional)</small>",
+                "placeholder": "Enter abstract",
+                "fieldClass": "clearfix",
+                "hidden": false,
+                "order": 9
+            },
+            "authors": {
+                "label": "<div>Authors</div><hr/>",
+                "hidden": false,
+                "items": {
+                    "label": "<span class=\"d-none\"></span>",
+                    "fields": {
+                        "author": {
+                            "label": "Name",
+                            "fieldClass": "body-text col-6 pull-left pl-0"
+                        },
+                        "orcid": {
+                            "label": "ORCiD",
+                            "fieldClass": "body-text col-6 pull-left pr-0"
+                        }
+                    }
+                },
+                "order": 10
+            },
+            "under-embargo": {
+                "type": "checkbox",
+                "rightLabel": "The material being submitted is published under an embargo.",
+                "fieldClass": "m-0 mt-4",
+                "hidden": false,
+                "order": 11
+            },
+            "Embargo-end-date": {
+                "type": "date",
+                "label": "Embargo End Date",
+                "helper": "<i>After the embargo end date, your submission manuscripts or article can be made public. <b>If this publication is not under embargo, please leave this field blank.<b></i>",
+                "helpersPosition": "above",
+                "placeholder": "dd/mm/yyyy",
+                "validate": true,
+                "inputType": "date",
+                "fieldClass": "date-time-picker",
+                "picker": {
+                    "format": "MM/DD/YY",
+                    "allowInputToggle": true
+                },
+                "order": 12,
+                "dependencies": {
+                    "under-embargo": true
+                }
+            }
+        }
+    }
+}

--- a/pass-core-metadataschema-service/src/test/resources/schemas/jhu/jscholarship.json
+++ b/pass-core-metadataschema-service/src/test/resources/schemas/jhu/jscholarship.json
@@ -1,0 +1,30 @@
+{
+    "title": "JScholarship schema",
+    "description": "JScholarship-specific metadata requirements",
+    "$id": "https://eclipse-pass.github.io/pass-metadata-schemas/schemas/jhu/jscholarship.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "definitions": {
+        "form": {
+            "title": "Johns Hopkins - JScholarship <br><p class='lead text-muted'>Deposit requirements for JH's institutional repository JScholarship</p>",
+            "type": "object",
+            "properties": {
+                "authors": {
+                    "$ref": "global.json#/properties/authors"
+                }
+            },
+            "required": ["authors"]
+        },
+        "options": {
+            "$ref": "global.json#/options"
+        }
+    },
+    "allOf": [
+        {
+            "$ref": "global.json#"
+        },
+        {
+            "$ref": "#/definitions/form"
+        }
+    ]
+}

--- a/pass-core-metadataschema-service/src/test/resources/schemas/jhu/jscholarship_deref.json
+++ b/pass-core-metadataschema-service/src/test/resources/schemas/jhu/jscholarship_deref.json
@@ -1,0 +1,488 @@
+{
+  "title": "JScholarship schema",
+  "description": "JScholarship-specific metadata requirements",
+  "$id": "https://eclipse-pass.github.io/pass-metadata-schemas/schemas/jhu/jscholarship.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "definitions": {
+    "form": {
+      "title": "Johns Hopkins - JScholarship <br><p class='lead text-muted'>Deposit requirements for JH's institutional repository JScholarship</p>",
+      "type": "object",
+      "properties": {
+        "authors": {
+          "type": "array",
+          "title": "Authors of this article or manuscript",
+          "description": "List of authors and their associated ORCIDS, if available",
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "title": "Author",
+            "properties": {
+              "author": {
+                "type": "string"
+              },
+              "orcid": {
+                "type": "string"
+              }
+            },
+            "required": ["author"]
+          }
+        }
+      },
+      "required": ["authors"]
+    },
+    "options": {
+      "fields": {
+        "title": {
+          "type": "textarea",
+          "label": "Article / Manuscript Title <small class=\"text-muted\">(required)</small>",
+          "placeholder": "Enter the manuscript title",
+          "rows": 2,
+          "cols": 100,
+          "hidden": false,
+          "order": 1
+        },
+        "journal-title": {
+          "type": "text",
+          "label": "Journal Title <small class=\"text-muted\">(required)</small>",
+          "placeholder": "Enter the journal title",
+          "hidden": false,
+          "order": 2
+        },
+        "journal-NLMTA-ID": {
+          "type": "text",
+          "label": "Journal NLMTA ID <small class=\"text-muted\">(optional)</small>",
+          "placeholder": "nlmta",
+          "order": 3
+        },
+        "volume": {
+          "type": "text",
+          "label": "Volume  <small class=\"text-muted\">(optional)</small>",
+          "placeholder": "Enter the volume",
+          "hidden": false,
+          "order": 4
+        },
+        "issue": {
+          "type": "text",
+          "label": "Issue  <small class=\"text-muted\">(optional)</small>",
+          "placeholder": "Enter issue",
+          "hidden": false,
+          "order": 5
+        },
+        "issns": {
+          "label": "<div>ISSN Information</div><hr/>",
+          "hidden": false,
+          "fieldClass": "",
+          "items": {
+            "label": "<span class=\"d-none\"></span>",
+            "fieldClass": "row",
+            "fields": {
+              "issn": {
+                "label": "ISSN",
+                "fieldClass": "body-text col-6 pull-left "
+              },
+              "pubType": {
+                "label": "Publication Type",
+                "fieldClass": "body-text col-6 pull-left md-pubtype",
+                "vertical": false,
+                "removeDefaultNone": true
+              }
+            }
+          },
+          "order": 6
+        },
+        "publisher": {
+          "type": "text",
+          "label": "Publisher <small class=\"text-muted\">(optional)</small>",
+          "placeholder": "Enter the Publisher",
+          "hidden": false,
+          "order": 7
+        },
+        "publicationDate": {
+          "type": "date",
+          "label": "Publication Date  <small class=\"text-muted\">(optional)</small>",
+          "hidden": false,
+          "order": 8
+        },
+        "abstract": {
+          "type": "textarea",
+          "label": "Abstract <small class=\"text-muted\">(optional)</small>",
+          "placeholder": "Enter abstract",
+          "fieldClass": "clearfix",
+          "hidden": false,
+          "order": 9
+        },
+        "authors": {
+          "label": "<div>Authors</div><hr/>",
+          "hidden": false,
+          "items": {
+            "label": "<span class=\"d-none\"></span>",
+            "fields": {
+              "author": {
+                "label": "Name",
+                "fieldClass": "body-text col-6 pull-left pl-0"
+              },
+              "orcid": {
+                "label": "ORCiD",
+                "fieldClass": "body-text col-6 pull-left pr-0"
+              }
+            }
+          },
+          "order": 10
+        },
+        "under-embargo": {
+          "type": "checkbox",
+          "rightLabel": "The material being submitted is published under an embargo.",
+          "fieldClass": "m-0 mt-4",
+          "hidden": false,
+          "order": 11
+        },
+        "Embargo-end-date": {
+          "type": "date",
+          "label": "Embargo End Date",
+          "helper": "<i>After the embargo end date, your submission manuscripts or article can be made public. <b>If this publication is not under embargo, please leave this field blank.<b></i>",
+          "helpersPosition": "above",
+          "placeholder": "dd/mm/yyyy",
+          "validate": true,
+          "inputType": "date",
+          "fieldClass": "date-time-picker",
+          "picker": {
+            "format": "MM/DD/YY",
+            "allowInputToggle": true
+          },
+          "order": 12,
+          "dependencies": {
+            "under-embargo": true
+          }
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "title": "JHU global schema",
+      "description": "Defines all possible metadata fields for PASS deposit",
+      "$id": "https://eclipse-pass.github.io/pass-metadata-schemas/schemas/jhu/global.json",
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "required": [
+        "$schema",
+        "title",
+        "journal-title"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "$schema": {
+          "type": "string",
+          "title": "JSON schema",
+          "description": "The JSON schema that applies to the resulting metadata blob"
+        },
+        "agreements": {
+          "type": "object",
+          "title": "Agreements to deposit conditions",
+          "description": "Maps repository keys to the text or links containing the agreements accepted by the submitter",
+          "$comment": "This was formerly known as 'embargo', available only for JScholarship metadata",
+          "patternProperties": {
+            "^.+$": {
+              "type": "string",
+              "title": "Agreement",
+              "description": "Text or link agreed to for the given repository key",
+              "$comment": "Example: {'jScholarship': 'http://example.org/agreementText'}"
+            }
+          }
+        },
+        "abstract": {
+          "type": "string",
+          "title": "Abstract",
+          "description": "The abstract of the article or manuscript being submitted"
+        },
+        "agent_information": {
+          "type": "object",
+          "title": "User agent (browser) information",
+          "description": "Contains the identity and version of the user's browser",
+          "properties": {
+            "name": {
+              "type": "string",
+              "title": "User agent (browser) name"
+            },
+            "version": {
+              "type": "string",
+              "title": "User agent (browser) version"
+            }
+          }
+        },
+        "authors": {
+          "type": "array",
+          "title": "Authors of this article or manuscript",
+          "description": "List of authors and their associated ORCIDS, if available",
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "title": "Author",
+            "properties": {
+              "author": {
+                "type": "string"
+              },
+              "orcid": {
+                "type": "string"
+              }
+            },
+            "required": ["author"]
+          }
+        },
+        "doi": {
+          "type": "string",
+          "pattern": "^10\\..+?/.+?$",
+          "title": "DOI of article",
+          "description": "The DOI of the individual article or manuscript submitted"
+        },
+        "Embargo-end-date": {
+          "type": "string",
+          "format": "date",
+          "title": "Embargo end date",
+          "description": "Date at which the article or manuscript may be made public"
+        },
+        "hints": {
+          "type": "object",
+          "title": "Hints provided by the UI to backend services",
+          "description": "Hints have semantics shared by the UI and the backend that are intended to influence the backend processing of the submission.",
+          "additionalProperties": false,
+          "properties": {
+            "collection-tags": {
+              "type": "array",
+              "uniqueItems": true,
+              "title": "Tags impacting the collection used by Deposit Services for deposit",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "journal-NLMTA-ID": {
+          "type": "string",
+          "title": "NTMLA",
+          "description": "NLM identifier for a journal"
+        },
+        "journal-title": {
+          "type": "string",
+          "title": "Journal title",
+          "description": "Title of the journal the individual article or manuscript was submitted to"
+        },
+        "journal-title-short": {
+          "type": "string",
+          "title": "Short journal title",
+          "description": "Short journal title from CrossRef"
+        },
+        "issue": {
+          "type": "string",
+          "title": "Journal issue",
+          "description": "Issue number of the journal this article or manuscript was submitted to"
+        },
+        "issns": {
+          "type": "array",
+          "title": "ISSN information for the manuscript's journal",
+          "description": "List of ISSN numbers with optional publication type",
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "title": "ISSN info",
+            "properties": {
+              "issn": {
+                "type": "string",
+                "title": "ISSN "
+              },
+              "pubType": {
+                "type": "string",
+                "title": "publication type",
+                "enum": ["Print", "Online"]
+              }
+            }
+          }
+        },
+        "publisher": {
+          "type": "string",
+          "title": "Publisher",
+          "description": "Publisher of the journal this article or manuscript was submitted to"
+        },
+        "publicationDate": {
+          "type": "string",
+          "title": "Publication Date",
+          "description": "Publication date of the journal or article this manuscript was submitted to",
+          "$comment": "This was formerly date-time format, but that appears too precise for values like 'Summer 2018'"
+        },
+        "title": {
+          "type": "string",
+          "title": "Article / Manuscript Title",
+          "description": "The title of the individual article or manuscript that was submitted"
+        },
+        "under-embargo": {
+          "type": "string",
+          "title": "Under Embargo",
+          "description": "Indicates wither the article or manuscript is under embargo",
+          "$comment": "This should probably be a boolean"
+        },
+        "volume": {
+          "type": "string",
+          "title": "Journal Volume",
+          "description": "journal volume this article or manuscript was published in"
+        }
+      },
+      "dependencies": {
+        "Embargo-end-date": ["under-embargo"]
+      },
+      "options": {
+        "fields": {
+          "title": {
+            "type": "textarea",
+            "label": "Article / Manuscript Title <small class=\"text-muted\">(required)</small>",
+            "placeholder": "Enter the manuscript title",
+            "rows": 2,
+            "cols": 100,
+            "hidden": false,
+            "order": 1
+          },
+          "journal-title": {
+            "type": "text",
+            "label": "Journal Title <small class=\"text-muted\">(required)</small>",
+            "placeholder": "Enter the journal title",
+            "hidden": false,
+            "order": 2
+          },
+          "journal-NLMTA-ID": {
+            "type": "text",
+            "label": "Journal NLMTA ID <small class=\"text-muted\">(optional)</small>",
+            "placeholder": "nlmta",
+            "order": 3
+          },
+          "volume": {
+            "type": "text",
+            "label": "Volume  <small class=\"text-muted\">(optional)</small>",
+            "placeholder": "Enter the volume",
+            "hidden": false,
+            "order": 4
+          },
+          "issue": {
+            "type": "text",
+            "label": "Issue  <small class=\"text-muted\">(optional)</small>",
+            "placeholder": "Enter issue",
+            "hidden": false,
+            "order": 5
+          },
+          "issns": {
+            "label": "<div>ISSN Information</div><hr/>",
+            "hidden": false,
+            "fieldClass": "",
+            "items": {
+              "label": "<span class=\"d-none\"></span>",
+              "fieldClass": "row",
+              "fields": {
+                "issn": {
+                  "label": "ISSN",
+                  "fieldClass": "body-text col-6 pull-left "
+                },
+                "pubType": {
+                  "label": "Publication Type",
+                  "fieldClass": "body-text col-6 pull-left md-pubtype",
+                  "vertical": false,
+                  "removeDefaultNone": true
+                }
+              }
+            },
+            "order": 6
+          },
+          "publisher": {
+            "type": "text",
+            "label": "Publisher <small class=\"text-muted\">(optional)</small>",
+            "placeholder": "Enter the Publisher",
+            "hidden": false,
+            "order": 7
+          },
+          "publicationDate": {
+            "type": "date",
+            "label": "Publication Date  <small class=\"text-muted\">(optional)</small>",
+            "hidden": false,
+            "order": 8
+          },
+          "abstract": {
+            "type": "textarea",
+            "label": "Abstract <small class=\"text-muted\">(optional)</small>",
+            "placeholder": "Enter abstract",
+            "fieldClass": "clearfix",
+            "hidden": false,
+            "order": 9
+          },
+          "authors": {
+            "label": "<div>Authors</div><hr/>",
+            "hidden": false,
+            "items": {
+              "label": "<span class=\"d-none\"></span>",
+              "fields": {
+                "author": {
+                  "label": "Name",
+                  "fieldClass": "body-text col-6 pull-left pl-0"
+                },
+                "orcid": {
+                  "label": "ORCiD",
+                  "fieldClass": "body-text col-6 pull-left pr-0"
+                }
+              }
+            },
+            "order": 10
+          },
+          "under-embargo": {
+            "type": "checkbox",
+            "rightLabel": "The material being submitted is published under an embargo.",
+            "fieldClass": "m-0 mt-4",
+            "hidden": false,
+            "order": 11
+          },
+          "Embargo-end-date": {
+            "type": "date",
+            "label": "Embargo End Date",
+            "helper": "<i>After the embargo end date, your submission manuscripts or article can be made public. <b>If this publication is not under embargo, please leave this field blank.<b></i>",
+            "helpersPosition": "above",
+            "placeholder": "dd/mm/yyyy",
+            "validate": true,
+            "inputType": "date",
+            "fieldClass": "date-time-picker",
+            "picker": {
+              "format": "MM/DD/YY",
+              "allowInputToggle": true
+            },
+            "order": 12,
+            "dependencies": {
+              "under-embargo": true
+            }
+          }
+        }
+      }
+
+    },
+    {
+      "title": "Johns Hopkins - JScholarship <br><p class='lead text-muted'>Deposit requirements for JH's institutional repository JScholarship</p>",
+      "type": "object",
+      "properties": {
+        "authors": {
+          "type": "array",
+          "title": "Authors of this article or manuscript",
+          "description": "List of authors and their associated ORCIDS, if available",
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "title": "Author",
+            "properties": {
+              "author": {
+                "type": "string"
+              },
+              "orcid": {
+                "type": "string"
+              }
+            },
+            "required": ["author"]
+          }
+        }
+      },
+      "required": ["authors"]
+    }
+  ]
+}

--- a/pass-core-metadataschema-service/src/test/resources/schemas/jhu/jscholarship_merge_deref.json
+++ b/pass-core-metadataschema-service/src/test/resources/schemas/jhu/jscholarship_merge_deref.json
@@ -1,0 +1,484 @@
+{
+  "type": "object",
+  "definitions": {
+    "form": {
+      "title": "Johns Hopkins - JScholarship <br><p class='lead text-muted'>Deposit requirements for JH's institutional repository JScholarship</p>",
+      "type": "object",
+      "properties": {
+        "authors": {
+          "type": "array",
+          "title": "Authors of this article or manuscript",
+          "description": "List of authors and their associated ORCIDS, if available",
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "title": "Author",
+            "properties": {
+              "author": {
+                "type": "string"
+              },
+              "orcid": {
+                "type": "string"
+              }
+            },
+            "required": ["author"]
+          }
+        }
+      },
+      "required": ["authors"]
+    },
+    "options": {
+      "fields": {
+        "title": {
+          "type": "textarea",
+          "label": "Article / Manuscript Title <small class=\"text-muted\">(required)</small>",
+          "placeholder": "Enter the manuscript title",
+          "rows": 2,
+          "cols": 100,
+          "hidden": false,
+          "order": 1
+        },
+        "journal-title": {
+          "type": "text",
+          "label": "Journal Title <small class=\"text-muted\">(required)</small>",
+          "placeholder": "Enter the journal title",
+          "hidden": false,
+          "order": 2
+        },
+        "journal-NLMTA-ID": {
+          "type": "text",
+          "label": "Journal NLMTA ID <small class=\"text-muted\">(optional)</small>",
+          "placeholder": "nlmta",
+          "order": 3
+        },
+        "volume": {
+          "type": "text",
+          "label": "Volume  <small class=\"text-muted\">(optional)</small>",
+          "placeholder": "Enter the volume",
+          "hidden": false,
+          "order": 4
+        },
+        "issue": {
+          "type": "text",
+          "label": "Issue  <small class=\"text-muted\">(optional)</small>",
+          "placeholder": "Enter issue",
+          "hidden": false,
+          "order": 5
+        },
+        "issns": {
+          "label": "<div>ISSN Information</div><hr/>",
+          "hidden": false,
+          "fieldClass": "",
+          "items": {
+            "label": "<span class=\"d-none\"></span>",
+            "fieldClass": "row",
+            "fields": {
+              "issn": {
+                "label": "ISSN",
+                "fieldClass": "body-text col-6 pull-left "
+              },
+              "pubType": {
+                "label": "Publication Type",
+                "fieldClass": "body-text col-6 pull-left md-pubtype",
+                "vertical": false,
+                "removeDefaultNone": true
+              }
+            }
+          },
+          "order": 6
+        },
+        "publisher": {
+          "type": "text",
+          "label": "Publisher <small class=\"text-muted\">(optional)</small>",
+          "placeholder": "Enter the Publisher",
+          "hidden": false,
+          "order": 7
+        },
+        "publicationDate": {
+          "type": "date",
+          "label": "Publication Date  <small class=\"text-muted\">(optional)</small>",
+          "hidden": false,
+          "order": 8
+        },
+        "abstract": {
+          "type": "textarea",
+          "label": "Abstract <small class=\"text-muted\">(optional)</small>",
+          "placeholder": "Enter abstract",
+          "fieldClass": "clearfix",
+          "hidden": false,
+          "order": 9
+        },
+        "authors": {
+          "label": "<div>Authors</div><hr/>",
+          "hidden": false,
+          "items": {
+            "label": "<span class=\"d-none\"></span>",
+            "fields": {
+              "author": {
+                "label": "Name",
+                "fieldClass": "body-text col-6 pull-left pl-0"
+              },
+              "orcid": {
+                "label": "ORCiD",
+                "fieldClass": "body-text col-6 pull-left pr-0"
+              }
+            }
+          },
+          "order": 10
+        },
+        "under-embargo": {
+          "type": "checkbox",
+          "rightLabel": "The material being submitted is published under an embargo.",
+          "fieldClass": "m-0 mt-4",
+          "hidden": false,
+          "order": 11
+        },
+        "Embargo-end-date": {
+          "type": "date",
+          "label": "Embargo End Date",
+          "helper": "<i>After the embargo end date, your submission manuscripts or article can be made public. <b>If this publication is not under embargo, please leave this field blank.<b></i>",
+          "helpersPosition": "above",
+          "placeholder": "dd/mm/yyyy",
+          "validate": true,
+          "inputType": "date",
+          "fieldClass": "date-time-picker",
+          "picker": {
+            "format": "MM/DD/YY",
+            "allowInputToggle": true
+          },
+          "order": 12,
+          "dependencies": {
+            "under-embargo": true
+          }
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "title": "JHU global schema",
+      "description": "Defines all possible metadata fields for PASS deposit",
+      "$id": "https://eclipse-pass.github.io/pass-metadata-schemas/schemas/jhu/global.json",
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "required": [
+        "$schema",
+        "title",
+        "journal-title"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "$schema": {
+          "type": "string",
+          "title": "JSON schema",
+          "description": "The JSON schema that applies to the resulting metadata blob"
+        },
+        "agreements": {
+          "type": "object",
+          "title": "Agreements to deposit conditions",
+          "description": "Maps repository keys to the text or links containing the agreements accepted by the submitter",
+          "$comment": "This was formerly known as 'embargo', available only for JScholarship metadata",
+          "patternProperties": {
+            "^.+$": {
+              "type": "string",
+              "title": "Agreement",
+              "description": "Text or link agreed to for the given repository key",
+              "$comment": "Example: {'jScholarship': 'http://example.org/agreementText'}"
+            }
+          }
+        },
+        "abstract": {
+          "type": "string",
+          "title": "Abstract",
+          "description": "The abstract of the article or manuscript being submitted"
+        },
+        "agent_information": {
+          "type": "object",
+          "title": "User agent (browser) information",
+          "description": "Contains the identity and version of the user's browser",
+          "properties": {
+            "name": {
+              "type": "string",
+              "title": "User agent (browser) name"
+            },
+            "version": {
+              "type": "string",
+              "title": "User agent (browser) version"
+            }
+          }
+        },
+        "authors": {
+          "type": "array",
+          "title": "Authors of this article or manuscript",
+          "description": "List of authors and their associated ORCIDS, if available",
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "title": "Author",
+            "properties": {
+              "author": {
+                "type": "string"
+              },
+              "orcid": {
+                "type": "string"
+              }
+            },
+            "required": ["author"]
+          }
+        },
+        "doi": {
+          "type": "string",
+          "pattern": "^10\\..+?/.+?$",
+          "title": "DOI of article",
+          "description": "The DOI of the individual article or manuscript submitted"
+        },
+        "Embargo-end-date": {
+          "type": "string",
+          "format": "date",
+          "title": "Embargo end date",
+          "description": "Date at which the article or manuscript may be made public"
+        },
+        "hints": {
+          "type": "object",
+          "title": "Hints provided by the UI to backend services",
+          "description": "Hints have semantics shared by the UI and the backend that are intended to influence the backend processing of the submission.",
+          "additionalProperties": false,
+          "properties": {
+            "collection-tags": {
+              "type": "array",
+              "uniqueItems": true,
+              "title": "Tags impacting the collection used by Deposit Services for deposit",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "journal-NLMTA-ID": {
+          "type": "string",
+          "title": "NTMLA",
+          "description": "NLM identifier for a journal"
+        },
+        "journal-title": {
+          "type": "string",
+          "title": "Journal title",
+          "description": "Title of the journal the individual article or manuscript was submitted to"
+        },
+        "journal-title-short": {
+          "type": "string",
+          "title": "Short journal title",
+          "description": "Short journal title from CrossRef"
+        },
+        "issue": {
+          "type": "string",
+          "title": "Journal issue",
+          "description": "Issue number of the journal this article or manuscript was submitted to"
+        },
+        "issns": {
+          "type": "array",
+          "title": "ISSN information for the manuscript's journal",
+          "description": "List of ISSN numbers with optional publication type",
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "title": "ISSN info",
+            "properties": {
+              "issn": {
+                "type": "string",
+                "title": "ISSN "
+              },
+              "pubType": {
+                "type": "string",
+                "title": "publication type",
+                "enum": ["Print", "Online"]
+              }
+            }
+          }
+        },
+        "publisher": {
+          "type": "string",
+          "title": "Publisher",
+          "description": "Publisher of the journal this article or manuscript was submitted to"
+        },
+        "publicationDate": {
+          "type": "string",
+          "title": "Publication Date",
+          "description": "Publication date of the journal or article this manuscript was submitted to",
+          "$comment": "This was formerly date-time format, but that appears too precise for values like 'Summer 2018'"
+        },
+        "title": {
+          "type": "string",
+          "title": "Article / Manuscript Title",
+          "description": "The title of the individual article or manuscript that was submitted"
+        },
+        "under-embargo": {
+          "type": "string",
+          "title": "Under Embargo",
+          "description": "Indicates wither the article or manuscript is under embargo",
+          "$comment": "This should probably be a boolean"
+        },
+        "volume": {
+          "type": "string",
+          "title": "Journal Volume",
+          "description": "journal volume this article or manuscript was published in"
+        }
+      },
+      "dependencies": {
+        "Embargo-end-date": ["under-embargo"]
+      },
+      "options": {
+        "fields": {
+          "title": {
+            "type": "textarea",
+            "label": "Article / Manuscript Title <small class=\"text-muted\">(required)</small>",
+            "placeholder": "Enter the manuscript title",
+            "rows": 2,
+            "cols": 100,
+            "hidden": false,
+            "order": 1
+          },
+          "journal-title": {
+            "type": "text",
+            "label": "Journal Title <small class=\"text-muted\">(required)</small>",
+            "placeholder": "Enter the journal title",
+            "hidden": false,
+            "order": 2
+          },
+          "journal-NLMTA-ID": {
+            "type": "text",
+            "label": "Journal NLMTA ID <small class=\"text-muted\">(optional)</small>",
+            "placeholder": "nlmta",
+            "order": 3
+          },
+          "volume": {
+            "type": "text",
+            "label": "Volume  <small class=\"text-muted\">(optional)</small>",
+            "placeholder": "Enter the volume",
+            "hidden": false,
+            "order": 4
+          },
+          "issue": {
+            "type": "text",
+            "label": "Issue  <small class=\"text-muted\">(optional)</small>",
+            "placeholder": "Enter issue",
+            "hidden": false,
+            "order": 5
+          },
+          "issns": {
+            "label": "<div>ISSN Information</div><hr/>",
+            "hidden": false,
+            "fieldClass": "",
+            "items": {
+              "label": "<span class=\"d-none\"></span>",
+              "fieldClass": "row",
+              "fields": {
+                "issn": {
+                  "label": "ISSN",
+                  "fieldClass": "body-text col-6 pull-left "
+                },
+                "pubType": {
+                  "label": "Publication Type",
+                  "fieldClass": "body-text col-6 pull-left md-pubtype",
+                  "vertical": false,
+                  "removeDefaultNone": true
+                }
+              }
+            },
+            "order": 6
+          },
+          "publisher": {
+            "type": "text",
+            "label": "Publisher <small class=\"text-muted\">(optional)</small>",
+            "placeholder": "Enter the Publisher",
+            "hidden": false,
+            "order": 7
+          },
+          "publicationDate": {
+            "type": "date",
+            "label": "Publication Date  <small class=\"text-muted\">(optional)</small>",
+            "hidden": false,
+            "order": 8
+          },
+          "abstract": {
+            "type": "textarea",
+            "label": "Abstract <small class=\"text-muted\">(optional)</small>",
+            "placeholder": "Enter abstract",
+            "fieldClass": "clearfix",
+            "hidden": false,
+            "order": 9
+          },
+          "authors": {
+            "label": "<div>Authors</div><hr/>",
+            "hidden": false,
+            "items": {
+              "label": "<span class=\"d-none\"></span>",
+              "fields": {
+                "author": {
+                  "label": "Name",
+                  "fieldClass": "body-text col-6 pull-left pl-0"
+                },
+                "orcid": {
+                  "label": "ORCiD",
+                  "fieldClass": "body-text col-6 pull-left pr-0"
+                }
+              }
+            },
+            "order": 10
+          },
+          "under-embargo": {
+            "type": "checkbox",
+            "rightLabel": "The material being submitted is published under an embargo.",
+            "fieldClass": "m-0 mt-4",
+            "hidden": false,
+            "order": 11
+          },
+          "Embargo-end-date": {
+            "type": "date",
+            "label": "Embargo End Date",
+            "helper": "<i>After the embargo end date, your submission manuscripts or article can be made public. <b>If this publication is not under embargo, please leave this field blank.<b></i>",
+            "helpersPosition": "above",
+            "placeholder": "dd/mm/yyyy",
+            "validate": true,
+            "inputType": "date",
+            "fieldClass": "date-time-picker",
+            "picker": {
+              "format": "MM/DD/YY",
+              "allowInputToggle": true
+            },
+            "order": 12,
+            "dependencies": {
+              "under-embargo": true
+            }
+          }
+        }
+      }
+
+    },
+    {
+      "title": "Johns Hopkins - JScholarship <br><p class='lead text-muted'>Deposit requirements for JH's institutional repository JScholarship</p>",
+      "type": "object",
+      "properties": {
+        "authors": {
+          "type": "array",
+          "title": "Authors of this article or manuscript",
+          "description": "List of authors and their associated ORCIDS, if available",
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "title": "Author",
+            "properties": {
+              "author": {
+                "type": "string"
+              },
+              "orcid": {
+                "type": "string"
+              }
+            },
+            "required": ["author"]
+          }
+        }
+      },
+      "required": ["authors"]
+    }
+  ]
+}

--- a/pass-core-metadataschema-service/src/test/resources/schemas/jhu/jscholarship_simple.json
+++ b/pass-core-metadataschema-service/src/test/resources/schemas/jhu/jscholarship_simple.json
@@ -1,0 +1,24 @@
+{
+  "title": "JScholarship schema",
+  "description": "JScholarship-specific metadata requirements",
+  "$id": "https://eclipse-pass.github.io/pass-metadata-schemas/schemas/jhu/jscholarship.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "definitions": {
+    "form": {
+      "title": "Johns Hopkins - JScholarship <br><p class='lead text-muted'>Deposit requirements for JH's institutional repository JScholarship</p>",
+      "type": "object",
+      "properties": {
+        "authors": {
+          "$ref": "global.json#/properties/authors"
+        }
+      },
+      "required": ["authors"]
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "#/definitions/form"
+    }
+  ]
+}

--- a/pass-core-metadataschema-service/src/test/resources/schemas/jhu/jscholarship_simple_deref.json
+++ b/pass-core-metadataschema-service/src/test/resources/schemas/jhu/jscholarship_simple_deref.json
@@ -1,0 +1,65 @@
+{
+  "title": "JScholarship schema",
+  "description": "JScholarship-specific metadata requirements",
+  "$id": "https://eclipse-pass.github.io/pass-metadata-schemas/schemas/jhu/jscholarship.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "definitions": {
+    "form": {
+      "title": "Johns Hopkins - JScholarship <br><p class='lead text-muted'>Deposit requirements for JH's institutional repository JScholarship</p>",
+      "type": "object",
+      "properties": {
+        "authors": {
+            "type": "array",
+            "title": "Authors of this article or manuscript",
+            "description": "List of authors and their associated ORCIDS, if available",
+            "uniqueItems": true,
+            "items": {
+              "type": "object",
+              "title": "Author",
+              "properties": {
+                "author": {
+                  "type": "string"
+                },
+                "orcid": {
+                  "type": "string"
+                }
+              },
+              "required": ["author"]
+            }
+          }
+      },
+      "required": ["authors"]
+    }
+  },
+  "allOf": [
+    {
+      "form": {
+        "title": "Johns Hopkins - JScholarship <br><p class='lead text-muted'>Deposit requirements for JH's institutional repository JScholarship</p>",
+        "type": "object",
+        "properties": {
+          "authors": {
+              "type": "array",
+              "title": "Authors of this article or manuscript",
+              "description": "List of authors and their associated ORCIDS, if available",
+              "uniqueItems": true,
+              "items": {
+                "type": "object",
+                "title": "Author",
+                "properties": {
+                  "author": {
+                    "type": "string"
+                  },
+                  "orcid": {
+                    "type": "string"
+                  }
+                },
+                "required": ["author"]
+              }
+            }
+        },
+        "required": ["authors"]
+      }
+    }
+  ]
+}

--- a/pass-core-metadataschema-service/src/test/resources/schemas/jhu/jscholarship_simple_deref.json
+++ b/pass-core-metadataschema-service/src/test/resources/schemas/jhu/jscholarship_simple_deref.json
@@ -34,7 +34,6 @@
   },
   "allOf": [
     {
-      "form": {
         "title": "Johns Hopkins - JScholarship <br><p class='lead text-muted'>Deposit requirements for JH's institutional repository JScholarship</p>",
         "type": "object",
         "properties": {
@@ -60,6 +59,5 @@
         },
         "required": ["authors"]
       }
-    }
   ]
 }

--- a/pass-core-metadataschema-service/src/test/resources/schemas/jhu/nihms.json
+++ b/pass-core-metadataschema-service/src/test/resources/schemas/jhu/nihms.json
@@ -1,0 +1,75 @@
+{
+    "title": "NIHMS schema",
+    "description": "NIHMS-specific metadata requirements",
+    "$id": "https://eclipse-pass.github.io/pass-metadata-schemas/schemas/jhu/nihms.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "definitions": {
+        "form": {
+            "title": "NIH Manuscript Submission System (NIHMS) <br><p class='lead text-muted'>The following metadata fields will be part of the NIHMS submission.</p>",
+            "type": "object",
+            "properties": {
+                "journal-NLMTA-ID": {
+                    "$ref": "global.json#/properties/journal-NLMTA-ID"
+                },
+                "issns": {
+                    "$ref": "global.json#/properties/issns"
+                }
+            }
+        },
+        "prerequisites": {
+            "anyOf": [
+                {"$ref": "#/definitions/nlmta_present"},
+                {"$ref": "#/definitions/issn_present"}
+            ]
+        },
+        "issn_present": {
+            "type": "object",
+            "properties": {
+                "issns": {
+                    "type": "array",
+                    "contains": {
+                        "type": "object",
+                        "required": [
+                            "issn",
+                            "pubType"
+                        ],
+                        "properties": {
+                            "issn": {
+                                "type": "string"
+                            },
+                            "pubType": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "nlmta_present": {
+            "type": "object",
+            "required": [
+                "journal-NLMTA-ID"
+            ],
+            "properties": {
+                "journal-NLMTA-ID": {
+                    "$ref": "global.json#/properties/journal-NLMTA-ID"
+                }
+            }
+        },
+        "options": {
+            "$ref": "global.json#/options"
+        }
+    },
+    "allOf": [
+        {
+            "$ref": "global.json#"
+        },
+        {
+            "$ref": "#/definitions/prerequisites"
+        },
+        {
+            "$ref": "#/definitions/form"
+        }
+    ]
+}

--- a/pass-core-metadataschema-service/src/test/resources/schemas/jhu/schema_to_deref.json
+++ b/pass-core-metadataschema-service/src/test/resources/schemas/jhu/schema_to_deref.json
@@ -2,9 +2,9 @@
   "$schema": "http://example.org/metadata-schemas/schemas/jhu/schema_to_dereference",
   "$id": "http://example.org/metadata-schemas/schemas/jhu/deref",
   "copySchemaName": {"$ref": "#/$schema"},
-  "schema1_title": {"$ref": "schema1.json#/x/title"},
-  "schema2_x": {"$ref": "schema2.json#/x"},
-  "schema3_array": {"$ref": "schema3.json#/array"},
-  "schema4_complexarray": {"$ref": "schema4.json#/complexarray"},
-  "schema4_hk": {"$ref": "schema4.json#/h/k"}
+  "title": {"$ref": "schema1.json#/x/title"},
+  "x": {"$ref": "schema2.json#/x"},
+  "array": {"$ref": "schema3.json#/array"},
+  "complexarray": {"$ref": "schema4.json#/complexarray"},
+  "k": {"$ref": "schema4.json#/h/k"}
 }

--- a/pass-core-metadataschema-service/src/test/resources/schemas/jhu/schema_to_deref_expected.json
+++ b/pass-core-metadataschema-service/src/test/resources/schemas/jhu/schema_to_deref_expected.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "http://example.org/metadata-schemas/schemas/jhu/schema_to_dereference",
+	"$id": "http://example.org/metadata-schemas/schemas/jhu/deref",
+	"copySchemaName": "http://example.org/metadata-schemas/schemas/jhu/schema_to_dereference",
+	"title": "X",
+	"x": {
+		"title": "x",
+		"description": "an awesome letter",
+		"$comment": "displays nicely",
+		"type": "letter"
+	},
+	"array": ["c", "d", "e"],
+	"complexarray": ["e", "f", {"g": "h"}],
+	"k": ["l", "m", "m'"]
+}


### PR DESCRIPTION
Service should send an array of relevant schemas in its response. If merge=true, return an array with only 1 element, otherwise return individual schemas in an array. 

PR also includes minor documentation fixes.

[Update metadata schemas service response#524](https://github.com/eclipse-pass/main/issues/524)