### PR TITLE
Clean code and tests

### DIFF
--- a/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/ExternalDoiService.java
+++ b/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/ExternalDoiService.java
@@ -38,10 +38,11 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class ExternalDoiService {
     private static final Logger LOG = LoggerFactory.getLogger(ExternalDoiService.class);
+
     private final Set<String> activeJobSet = new HashSet<>();
     private final Set<String> syncActiveJobSet = Collections.synchronizedSet(activeJobSet);
 
-    String MAILTO = "pass@jhu.edu";
+    final static String MAILTO = "pass@jhu.edu";
 
     /**
      * The name of the external service

--- a/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/PassDoiServiceController.java
+++ b/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/PassDoiServiceController.java
@@ -36,14 +36,14 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 public class PassDoiServiceController {
-
     private static final Logger LOG = LoggerFactory.getLogger(PassDoiServiceController.class);
-    ElideConnector elideConnector;
-    ExternalDoiServiceConnector externalDoiServiceConnector;
-    ExternalDoiService xrefDoiService;
-    ExternalDoiService unpaywallDoiService;
 
-    PassDoiServiceController(RefreshableElide refreshableElide) {
+    private final ElideConnector elideConnector;
+    private final ExternalDoiServiceConnector externalDoiServiceConnector;
+    private final ExternalDoiService xrefDoiService;
+    private final ExternalDoiService unpaywallDoiService;
+
+    public PassDoiServiceController(RefreshableElide refreshableElide) {
         this.elideConnector = new ElideConnector(refreshableElide);
         this.externalDoiServiceConnector = new ExternalDoiServiceConnector();
         this.xrefDoiService = new XrefDoiService();

--- a/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/UnpaywallDoiService.java
+++ b/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/UnpaywallDoiService.java
@@ -26,7 +26,7 @@ import javax.json.JsonValue;
 /**
  * The UnpaywallDoiService class is an implementation of the ExternalDoiService abstract class to interface with
  * the Unpaywall API. The Unpaywall API is a RESTful API that returns JSON metadata for a given DOI. More information
- * about the Unpaywall API can be found here: https://unpaywall.org/products/api
+ * about the Unpaywall API can be found here: <a href="https://unpaywall.org/products/api">Unpaywall API</a>
  */
 public class UnpaywallDoiService extends ExternalDoiService {
 

--- a/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/XrefDoiService.java
+++ b/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/XrefDoiService.java
@@ -22,9 +22,9 @@ import javax.json.JsonObject;
 /**
  * The XrefDoiService class is an implementation of the ExternalDoiService abstract class to interface with the Crossref
  * API. The Crossref API is a RESTful API that returns JSON metadata for a given DOI.
- *
- * The Crossref API is documented here: https://api.crossref.org/
- *
+ * <p>
+ * The Crossref API is documented here: <a href="https://api.crossref.org/">Crossref API</a>
+ * <p>
  * The Crossref API requires a User-Agent header to be set on the request. The value of this header must be an email
  * address. The default email address used by is pass@jhu.edu and can be overridden by setting the environment variable
  * PASS_DOI_SERVICE_MAILTO

--- a/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/XrefDoiService.java
+++ b/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/XrefDoiService.java
@@ -31,7 +31,7 @@ import javax.json.JsonObject;
  */
 public class XrefDoiService extends ExternalDoiService {
 
-    String XREF_BASEURI = "https://api.crossref.org/v1/works/";
+    private final static String XREF_BASEURI = "https://api.crossref.org/v1/works/";
 
     @Override
     public String name() {

--- a/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/PassFileServiceController.java
+++ b/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/PassFileServiceController.java
@@ -23,8 +23,6 @@ import org.eclipse.pass.file.service.storage.FileStorageService;
 import org.eclipse.pass.file.service.storage.StorageFile;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Lazy;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -49,14 +47,13 @@ import org.springframework.web.multipart.MultipartFile;
 public class PassFileServiceController {
     private static final Logger LOG = LoggerFactory.getLogger(PassFileServiceController.class);
 
-    @Lazy
-    @Autowired
-    private FileStorageService fileStorageService;
+    private final FileStorageService fileStorageService;
 
     /**
      *   Class constructor.
      */
-    public PassFileServiceController() {
+    public PassFileServiceController(FileStorageService fileStorageService) {
+        this.fileStorageService = fileStorageService;
     }
 
     /**

--- a/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/storage/FileStorageService.java
+++ b/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/storage/FileStorageService.java
@@ -92,7 +92,6 @@ public class FileStorageService {
     private S3Client cloudS3Client;
     private String bucketName;
     private String repoPrefix;
-    private Region region;
 
     /**
      *  FileStorageService Class constructor.
@@ -164,6 +163,7 @@ public class FileStorageService {
                 throw new IOException("File Service: S3 bucket name is not set");
             }
 
+            Region region;
             if (storageProperties.getRegion().isPresent()) {
                 region = storageProperties.getRegion().get();
             } else {

--- a/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/storage/StorageFile.java
+++ b/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/storage/StorageFile.java
@@ -185,7 +185,7 @@ public class StorageFile {
     }
 
     @Override
-    public boolean equals(java.lang.Object o) {
+    public boolean equals(Object o) {
         if (this == o) {
             return true;
         }
@@ -224,7 +224,7 @@ public class StorageFile {
      * Convert the given object to string with each line indented by 4 spaces
      * (except the first line).
      */
-    private String toIndentedString(java.lang.Object o) {
+    private String toIndentedString(Object o) {
         if (o == null) {
             return "null";
         }

--- a/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/storage/StorageProperties.java
+++ b/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/storage/StorageProperties.java
@@ -31,9 +31,9 @@ import software.amazon.awssdk.regions.Region;
  */
 @ConfigurationProperties(prefix = "spring.file-service")
 public class StorageProperties {
-    private final String ocflDir = "ocfl";
-    private final String ocflWorkDir = "ocfl-work";
-    private final String tempDir = "temp";
+    private final static String OCFL_DIR = "ocfl";
+    private final static String OCFL_WORK_DIR = "ocfl-work";
+    private final static String TEMP_DIR = "temp";
     private String rootDir;
     private StorageServiceType storageType;
     private String s3BucketName;
@@ -56,7 +56,7 @@ public class StorageProperties {
      * @return The logical path of the OCFL storage directory
      */
     public String getStorageOcflDir() {
-        return ocflDir;
+        return OCFL_DIR;
     }
 
     /**
@@ -66,7 +66,7 @@ public class StorageProperties {
      * @return The logical path of the OCFL working directory
      */
     public String getStorageWorkDir() {
-        return ocflWorkDir;
+        return OCFL_WORK_DIR;
     }
 
     /**
@@ -75,7 +75,7 @@ public class StorageProperties {
      * @return The logical path of the temp directory
      */
     public String getStorageTempDir() {
-        return tempDir;
+        return TEMP_DIR;
     }
 
     /**

--- a/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/storage/StorageProperties.java
+++ b/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/storage/StorageProperties.java
@@ -18,8 +18,6 @@ package org.eclipse.pass.file.service.storage;
 
 import java.util.Optional;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import software.amazon.awssdk.regions.Region;
 
@@ -33,7 +31,6 @@ import software.amazon.awssdk.regions.Region;
  */
 @ConfigurationProperties(prefix = "spring.file-service")
 public class StorageProperties {
-    private static final Logger LOG = LoggerFactory.getLogger(StorageProperties.class);
     private final String ocflDir = "ocfl";
     private final String ocflWorkDir = "ocfl-work";
     private final String tempDir = "temp";

--- a/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/storage/StorageServiceType.java
+++ b/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/storage/StorageServiceType.java
@@ -19,7 +19,7 @@ public enum StorageServiceType {
      * Get the string value of the StorageServiceType. Can be either an 'FILE_SYSTEM' or 'S3'
      */
     public final String label;
-    private StorageServiceType(String label) {
+    StorageServiceType(String label) {
         this.label = label;
     }
 }

--- a/pass-core-main/src/main/java/org/eclipse/pass/main/security/ShibAuthenticationFilter.java
+++ b/pass-core-main/src/main/java/org/eclipse/pass/main/security/ShibAuthenticationFilter.java
@@ -48,10 +48,10 @@ import static org.eclipse.pass.main.security.ShibConstants.*;
  * Filter responsible for mapping a Shib user to a PASS user. The PASS user is
  * created if it does not exist and otherwise updated to reflect the information
  * provided by Shib. The PASS user name becomes the name of the Principal.
- *
+ * <p>
  * If the request does not look like it came from Shib, the mapping step is skipped.
  * In any case, the request is passed down the chain.
- *
+ * <p>
  * A cache of maximum size pass.auth.max-cache-size of recent authentications is
  * maintained. It is cleared every pass.auth.cache-duration minutes.
  */

--- a/pass-core-main/src/main/java/org/eclipse/pass/main/security/ShibAuthenticationFilter.java
+++ b/pass-core-main/src/main/java/org/eclipse/pass/main/security/ShibAuthenticationFilter.java
@@ -42,8 +42,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import static org.eclipse.pass.main.security.ShibConstants.*;
-
 /**
  * Filter responsible for mapping a Shib user to a PASS user. The PASS user is
  * created if it does not exist and otherwise updated to reflect the information
@@ -192,38 +190,38 @@ public class ShibAuthenticationFilter extends OncePerRequestFilter {
     protected static User parseShibHeaders(HttpServletRequest request) {
         User user = new User();
 
-        String display_name = get_shib_attr(request, DISPLAY_NAME_HEADER, true);
-        String given_name = get_shib_attr(request, GIVENNAME_HEADER, true);
-        String surname = get_shib_attr(request, SN_HEADER, true);
-        String email = get_shib_attr(request, EMAIL_HEADER, true);
-        String eppn = get_shib_attr(request, EPPN_HEADER, true);
-        String employee_id = get_shib_attr(request, EMPLOYEE_ID_HEADER, false);
-        String unique_id = get_shib_attr(request, UNIQUE_ID_HEADER, true);
-        String affiliation = get_shib_attr(request, SCOPED_AFFILIATION_HEADER, false);
+        String display_name = get_shib_attr(request, ShibConstants.DISPLAY_NAME_HEADER, true);
+        String given_name = get_shib_attr(request, ShibConstants.GIVENNAME_HEADER, true);
+        String surname = get_shib_attr(request, ShibConstants.SN_HEADER, true);
+        String email = get_shib_attr(request, ShibConstants.EMAIL_HEADER, true);
+        String eppn = get_shib_attr(request, ShibConstants.EPPN_HEADER, true);
+        String employee_id = get_shib_attr(request, ShibConstants.EMPLOYEE_ID_HEADER, false);
+        String unique_id = get_shib_attr(request, ShibConstants.UNIQUE_ID_HEADER, true);
+        String affiliation = get_shib_attr(request, ShibConstants.SCOPED_AFFILIATION_HEADER, false);
 
         String[] eppn_parts = eppn.split("@");
 
         if (eppn_parts.length != 2) {
-            throw new BadCredentialsException("Shib header malformed: " + EPPN_HEADER);
+            throw new BadCredentialsException("Shib header malformed: " + ShibConstants.EPPN_HEADER);
         }
 
         String domain = eppn_parts[1];
         String institutional_id = eppn_parts[0].toLowerCase();
 
         if (domain.isEmpty() || institutional_id.isEmpty()) {
-            throw new BadCredentialsException("Shib header malformed: " + EPPN_HEADER);
+            throw new BadCredentialsException("Shib header malformed: " + ShibConstants.EPPN_HEADER);
         }
 
-        unique_id = String.join(":", domain, UNIQUE_ID_TYPE, unique_id.split("@")[0]);
+        unique_id = String.join(":", domain, ShibConstants.UNIQUE_ID_TYPE, unique_id.split("@")[0]);
 
         // The locator id list has durable ids first.
         user.getLocatorIds().add(unique_id);
 
-        institutional_id = String.join(":", domain, JHED_ID_TYPE, institutional_id);
+        institutional_id = String.join(":", domain, ShibConstants.JHED_ID_TYPE, institutional_id);
         user.getLocatorIds().add(institutional_id);
 
         if (employee_id != null && !employee_id.isEmpty()) {
-            employee_id = String.join(":", domain, EMPLOYEE_ID_TYPE, employee_id);
+            employee_id = String.join(":", domain, ShibConstants.EMPLOYEE_ID_TYPE, employee_id);
             user.getLocatorIds().add(employee_id);
         }
 
@@ -250,7 +248,7 @@ public class ShibAuthenticationFilter extends OncePerRequestFilter {
      * @return whether or not this looks like a Shib request
      */
     protected static boolean isShibRequest(HttpServletRequest request) {
-        return has_all_headers(request, EPPN_HEADER, UNIQUE_ID_HEADER);
+        return has_all_headers(request, ShibConstants.EPPN_HEADER, ShibConstants.UNIQUE_ID_HEADER);
     }
 
     private static boolean has_all_headers(HttpServletRequest request, String... names) {

--- a/pass-core-main/src/main/java/org/eclipse/pass/main/security/ShibAuthenticationFilter.java
+++ b/pass-core-main/src/main/java/org/eclipse/pass/main/security/ShibAuthenticationFilter.java
@@ -42,6 +42,8 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+import static org.eclipse.pass.main.security.ShibConstants.*;
+
 /**
  * Filter responsible for mapping a Shib user to a PASS user. The PASS user is
  * created if it does not exist and otherwise updated to reflect the information
@@ -54,7 +56,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
  * maintained. It is cleared every pass.auth.cache-duration minutes.
  */
 @Component
-public class ShibAuthenticationFilter extends OncePerRequestFilter implements ShibConstants {
+public class ShibAuthenticationFilter extends OncePerRequestFilter {
     private static final Logger LOG = LoggerFactory.getLogger(ShibAuthenticationFilter.class);
 
     private final ConcurrentHashMap<String, ShibAuthentication> auth_cache;
@@ -78,8 +80,8 @@ public class ShibAuthenticationFilter extends OncePerRequestFilter implements Sh
 
     // Do authentication and return Authentication object representing success.
     // Throw AuthenticationException if there is trouble with the user credentials
-    private Authentication authenticate(HttpServletRequest request, HttpServletResponse response)
-            throws AuthenticationException, IOException, ServletException {
+    private Authentication authenticate(HttpServletRequest request)
+            throws AuthenticationException, IOException {
         if (LOG.isDebugEnabled()) {
             LOG.debug("Request headers:");
             request.getHeaderNames().asIterator().forEachRemaining(s -> {
@@ -294,7 +296,7 @@ public class ShibAuthenticationFilter extends OncePerRequestFilter implements Sh
 
         if (isShibRequest(request)) {
             try {
-                Authentication auth = authenticate(request, response);
+                Authentication auth = authenticate(request);
                 SecurityContextHolder.getContext().setAuthentication(auth);
 
                 LOG.debug("Shib user logged in {}", auth.getName());

--- a/pass-core-main/src/main/java/org/eclipse/pass/main/security/ShibConstants.java
+++ b/pass-core-main/src/main/java/org/eclipse/pass/main/security/ShibConstants.java
@@ -18,7 +18,10 @@ package org.eclipse.pass.main.security;
 /**
  * Various constants associated with Shib authentication
  */
-public interface ShibConstants {
+public final class ShibConstants {
+
+    private ShibConstants() {}
+
     /** Display name http header */
     public static final String DISPLAY_NAME_HEADER = "Displayname";
 

--- a/pass-core-main/src/test/java/org/eclipse/pass/main/IntegrationTest.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/main/IntegrationTest.java
@@ -44,7 +44,7 @@ public abstract class IntegrationTest {
     }
 
     @BeforeAll
-    public void setup() {
+    void setup() {
         RestAssured.port = port;
     }
 }

--- a/pass-core-main/src/test/java/org/eclipse/pass/main/ShibIntegrationTest.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/main/ShibIntegrationTest.java
@@ -7,14 +7,13 @@ import java.util.UUID;
 import com.yahoo.elide.RefreshableElide;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
+import org.eclipse.pass.main.security.ShibConstants;
 import org.eclipse.pass.object.PassClient;
 import org.eclipse.pass.object.model.User;
 import org.eclipse.pass.object.model.UserRole;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import static org.eclipse.pass.main.security.ShibConstants.*;
 
 /**
  * Provide a Shib user to make requests.
@@ -84,13 +83,13 @@ public class ShibIntegrationTest extends IntegrationTest {
     }
 
     protected void setShibHeaders(Request.Builder builder) {
-        builder.addHeader(SCOPED_AFFILIATION_HEADER, SUBMITTER_SCOPED_AFFILIATION);
-        builder.addHeader(SN_HEADER, SUBMITTER_SUR_NAME);
-        builder.addHeader(GIVENNAME_HEADER, SUBMITTER_GIVEN_NAME);
-        builder.addHeader(UNIQUE_ID_HEADER, getSubmitterUniqueId());
-        builder.addHeader(EMAIL_HEADER, SUBMITTER_EMAIL);
-        builder.addHeader(EMPLOYEE_ID_HEADER, getSubmitterEmployeeId());
-        builder.addHeader(DISPLAY_NAME_HEADER, SUBMITTER_NAME);
-        builder.addHeader(EPPN_HEADER, getSubmitterEppn());
+        builder.addHeader(ShibConstants.SCOPED_AFFILIATION_HEADER, SUBMITTER_SCOPED_AFFILIATION);
+        builder.addHeader(ShibConstants.SN_HEADER, SUBMITTER_SUR_NAME);
+        builder.addHeader(ShibConstants.GIVENNAME_HEADER, SUBMITTER_GIVEN_NAME);
+        builder.addHeader(ShibConstants.UNIQUE_ID_HEADER, getSubmitterUniqueId());
+        builder.addHeader(ShibConstants.EMAIL_HEADER, SUBMITTER_EMAIL);
+        builder.addHeader(ShibConstants.EMPLOYEE_ID_HEADER, getSubmitterEmployeeId());
+        builder.addHeader(ShibConstants.DISPLAY_NAME_HEADER, SUBMITTER_NAME);
+        builder.addHeader(ShibConstants.EPPN_HEADER, getSubmitterEppn());
     }
 }

--- a/pass-core-main/src/test/java/org/eclipse/pass/main/ShibIntegrationTest.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/main/ShibIntegrationTest.java
@@ -7,7 +7,6 @@ import java.util.UUID;
 import com.yahoo.elide.RefreshableElide;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
-import org.eclipse.pass.main.security.ShibConstants;
 import org.eclipse.pass.object.PassClient;
 import org.eclipse.pass.object.model.User;
 import org.eclipse.pass.object.model.UserRole;
@@ -15,10 +14,12 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import static org.eclipse.pass.main.security.ShibConstants.*;
+
 /**
  * Provide a Shib user to make requests.
  */
-public class ShibIntegrationTest extends IntegrationTest implements ShibConstants {
+public class ShibIntegrationTest extends IntegrationTest {
     protected static String SUBMITTER_NAME = "Sally M. Submitter";
     protected static String SUBMITTER_SUR_NAME = "Submitter";
     protected static String SUBMITTER_GIVEN_NAME = "Sally";
@@ -35,7 +36,7 @@ public class ShibIntegrationTest extends IntegrationTest implements ShibConstant
     protected RefreshableElide refreshableElide;
 
     @BeforeAll
-    private static void setupTests() throws IOException {
+    void setupTests() {
         client = new OkHttpClient.Builder().followRedirects(false).build();
         submitter = new User();
 
@@ -53,7 +54,7 @@ public class ShibIntegrationTest extends IntegrationTest implements ShibConstant
     }
 
     @BeforeEach
-    private void persistSubmitter() throws IOException {
+    void persistSubmitter() throws IOException {
         // Create the submitter once
         if (submitter.getId() == null) {
             try (PassClient pass_client = PassClient.newInstance(refreshableElide)) {

--- a/pass-core-main/src/test/java/org/eclipse/pass/main/security/AccessControlTest.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/main/security/AccessControlTest.java
@@ -15,6 +15,13 @@
  */
 package org.eclipse.pass.main.security;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.IOException;
 
 import okhttp3.Credentials;
@@ -33,9 +40,6 @@ import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.security.authentication.BadCredentialsException;
-
-import static org.eclipse.pass.main.security.ShibConstants.*;
-import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Ensure that HTTP requests are authenticated and authorized appropriately.
@@ -159,14 +163,14 @@ public class AccessControlTest extends ShibIntegrationTest {
     public void testParseShibHeaders() {
         MockHttpServletRequest req = new MockHttpServletRequest();
 
-        req.addHeader(SCOPED_AFFILIATION_HEADER, SUBMITTER_SCOPED_AFFILIATION);
-        req.addHeader(SN_HEADER, SUBMITTER_SUR_NAME);
-        req.addHeader(GIVENNAME_HEADER, SUBMITTER_GIVEN_NAME);
-        req.addHeader(UNIQUE_ID_HEADER, getSubmitterUniqueId());
-        req.addHeader(EMAIL_HEADER, SUBMITTER_EMAIL);
-        req.addHeader(EMPLOYEE_ID_HEADER, getSubmitterEmployeeId());
-        req.addHeader(DISPLAY_NAME_HEADER, SUBMITTER_NAME);
-        req.addHeader(EPPN_HEADER, getSubmitterEppn());
+        req.addHeader(ShibConstants.SCOPED_AFFILIATION_HEADER, SUBMITTER_SCOPED_AFFILIATION);
+        req.addHeader(ShibConstants.SN_HEADER, SUBMITTER_SUR_NAME);
+        req.addHeader(ShibConstants.GIVENNAME_HEADER, SUBMITTER_GIVEN_NAME);
+        req.addHeader(ShibConstants.UNIQUE_ID_HEADER, getSubmitterUniqueId());
+        req.addHeader(ShibConstants.EMAIL_HEADER, SUBMITTER_EMAIL);
+        req.addHeader(ShibConstants.EMPLOYEE_ID_HEADER, getSubmitterEmployeeId());
+        req.addHeader(ShibConstants.DISPLAY_NAME_HEADER, SUBMITTER_NAME);
+        req.addHeader(ShibConstants.EPPN_HEADER, getSubmitterEppn());
 
         assertTrue(ShibAuthenticationFilter.isShibRequest(req));
 
@@ -188,8 +192,8 @@ public class AccessControlTest extends ShibIntegrationTest {
 
         // Enough headers to look like a request
 
-        req.addHeader(UNIQUE_ID_HEADER, getSubmitterUniqueId());
-        req.addHeader(EPPN_HEADER, getSubmitterEppn());
+        req.addHeader(ShibConstants.UNIQUE_ID_HEADER, getSubmitterUniqueId());
+        req.addHeader(ShibConstants.EPPN_HEADER, getSubmitterEppn());
 
         assertTrue(ShibAuthenticationFilter.isShibRequest(req));
         assertThrows(BadCredentialsException.class, () -> ShibAuthenticationFilter.parseShibHeaders(req));

--- a/pass-core-main/src/test/java/org/eclipse/pass/main/security/AccessControlTest.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/main/security/AccessControlTest.java
@@ -15,12 +15,6 @@
  */
 package org.eclipse.pass.main.security;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.io.IOException;
 
 import okhttp3.Credentials;
@@ -39,6 +33,9 @@ import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.security.authentication.BadCredentialsException;
+
+import static org.eclipse.pass.main.security.ShibConstants.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Ensure that HTTP requests are authenticated and authorized appropriately.
@@ -61,7 +58,7 @@ public class AccessControlTest extends ShibIntegrationTest {
             try {
                 return new JSONObject(json);
             } catch (JSONException e) {
-                assertTrue(false, "Expected JSON object, got: " + json);
+                fail("Expected JSON object, got: " + json);
             }
         }
 
@@ -114,9 +111,7 @@ public class AccessControlTest extends ShibIntegrationTest {
 
     private void print(Response response) throws IOException {
         System.err.println(response.code() + " " + response.message());
-        response.headers().names().forEach(h -> {
-            System.err.println("  " + h + ": " + response.header(h));
-        });
+        response.headers().names().forEach(h -> System.err.println("  " + h + ": " + response.header(h)));
         System.err.println(response.body().string());
     }
 
@@ -189,9 +184,7 @@ public class AccessControlTest extends ShibIntegrationTest {
         // No headers
 
         assertFalse(ShibAuthenticationFilter.isShibRequest(req));
-        assertThrows(BadCredentialsException.class, () -> {
-            ShibAuthenticationFilter.parseShibHeaders(req);
-        });
+        assertThrows(BadCredentialsException.class, () -> ShibAuthenticationFilter.parseShibHeaders(req));
 
         // Enough headers to look like a request
 
@@ -199,9 +192,7 @@ public class AccessControlTest extends ShibIntegrationTest {
         req.addHeader(EPPN_HEADER, getSubmitterEppn());
 
         assertTrue(ShibAuthenticationFilter.isShibRequest(req));
-        assertThrows(BadCredentialsException.class, () -> {
-            ShibAuthenticationFilter.parseShibHeaders(req);
-        });
+        assertThrows(BadCredentialsException.class, () -> ShibAuthenticationFilter.parseShibHeaders(req));
     }
 
     @Test

--- a/pass-core-main/src/test/java/org/eclipse/pass/metadataschema/MetadataSchemaServiceTest.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/metadataschema/MetadataSchemaServiceTest.java
@@ -48,9 +48,6 @@ public class MetadataSchemaServiceTest extends IntegrationTest {
 
     @Test
     public void testSchemaControllerOneRepoWithMergeTrue() throws Exception {
-        List<URI> r1_schemas_list = Arrays.asList(new URI("https://example.com/metadata-schemas/jhu/schema1.json"),
-                new URI("https://example.com/metadata-schemas/jhu/schema2.json"));
-
         String url = getBaseUrl() + "schema?entityIds=" + repo1Id.toString() + "&merge=true";
         Request okHttpRequest = new Request.Builder()
                 .url(url).header("Authorization", credentials)

--- a/pass-core-main/src/test/java/org/eclipse/pass/metadataschema/MetadataSchemaServiceTest.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/metadataschema/MetadataSchemaServiceTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Arrays;
-import java.util.List;
 
 import com.yahoo.elide.RefreshableElide;
 import okhttp3.Call;

--- a/pass-core-main/src/test/resources/logback-test.xml
+++ b/pass-core-main/src/test/resources/logback-test.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{dd-MM-yyyy HH:mm:ss.SSS} %magenta([%thread]) [${springAppName}, %X{X-B3-TraceId:-}] %highlight(%-5level) %logger{36}.%M - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- Change level attribute or add logger elements to see more logging in console for tests  -->
+    <root level="WARN">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/pass-core-metadataschema-service/src/main/java/org/eclipse/pass/metadataschema/PassSchemaServiceController.java
+++ b/pass-core-metadataschema-service/src/main/java/org/eclipse/pass/metadataschema/PassSchemaServiceController.java
@@ -51,7 +51,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class PassSchemaServiceController {
     private static final Logger LOG = LoggerFactory.getLogger(PassSchemaServiceController.class);
     private final PassClient passClient;
-    private SchemaService schemaService;
+    private final SchemaService schemaService;
 
     /**
      * Constructor for PassSchemaServiceController
@@ -96,12 +96,11 @@ public class PassSchemaServiceController {
      * @throws Exception if there is an error reading the request body
      */
     protected List<String> readJson(BufferedReader r) throws Exception {
-        String next;
         String json_list = r.readLine();
         ObjectMapper o = new ObjectMapper();
         List<String> repository_list = o.readValue(json_list, new TypeReference<ArrayList<String>>() {
         });
-        if ((next = r.readLine()) != null) {
+        if (r.readLine() != null) {
             throw new Exception("Too many lines");
         }
         return repository_list;
@@ -132,7 +131,6 @@ public class PassSchemaServiceController {
 
         ObjectMapper objectMapper = new ObjectMapper();
         ArrayNode responseArray = objectMapper.createArrayNode();
-        String jsonResponse = "";
 
         //front-end will first attempt to merge schemas, if that fails, it will attempt to retrieve individual schemas
         if (mergeSchemaOpt.equalsIgnoreCase("true")) {
@@ -160,7 +158,7 @@ public class PassSchemaServiceController {
             }
         }
 
-        jsonResponse = objectMapper.writeValueAsString(responseArray);
+        String jsonResponse = objectMapper.writeValueAsString(responseArray);
         HttpHeaders headers = new HttpHeaders();
         //APPLICATION_JSON_UTF8 is deprecated and APPLICATION_JSON is preferred, will be interpreted as UTF-8
         headers.setContentType(MediaType.APPLICATION_JSON);

--- a/pass-core-metadataschema-service/src/main/java/org/eclipse/pass/metadataschema/PassSchemaServiceController.java
+++ b/pass-core-metadataschema-service/src/main/java/org/eclipse/pass/metadataschema/PassSchemaServiceController.java
@@ -27,11 +27,8 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.yahoo.elide.RefreshableElide;
-import org.eclipse.pass.object.PassClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -50,28 +47,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class PassSchemaServiceController {
     private static final Logger LOG = LoggerFactory.getLogger(PassSchemaServiceController.class);
-    private final PassClient passClient;
+
     private final SchemaService schemaService;
 
     /**
      * Constructor for PassSchemaServiceController
-     *
-     * @param refreshableElide Elide instance used for interfacing with the PASS data model
+     * @param schemaService the service responsible for managing schemas
      */
-    @Autowired
-    public PassSchemaServiceController(RefreshableElide refreshableElide) {
-        this.passClient = PassClient.newInstance(refreshableElide);
-        schemaService = new SchemaService(passClient);
-    }
-
-    /**
-     * This constructor is used for unit testing to inject a mock client
-     *
-     * @param passClient PassClient to use for unit testing
-     */
-    protected PassSchemaServiceController(PassClient passClient) {
-        this.passClient = passClient;
-        schemaService = new SchemaService(passClient);
+    public PassSchemaServiceController(SchemaService schemaService) {
+        this.schemaService = schemaService;
     }
 
     /**

--- a/pass-core-metadataschema-service/src/main/java/org/eclipse/pass/metadataschema/SchemaFetcher.java
+++ b/pass-core-metadataschema-service/src/main/java/org/eclipse/pass/metadataschema/SchemaFetcher.java
@@ -46,7 +46,7 @@ public class SchemaFetcher {
 
     private final PassClient passClient;
     private static final Logger LOG = LoggerFactory.getLogger(SchemaFetcher.class);
-    private static ConcurrentHashMap<String, JsonNode> localSchemaCache = new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<String, JsonNode> localSchemaCache = new ConcurrentHashMap<>();
 
     /**
      * Constructor for SchemaFetcher

--- a/pass-core-metadataschema-service/src/main/java/org/eclipse/pass/metadataschema/SchemaInstance.java
+++ b/pass-core-metadataschema-service/src/main/java/org/eclipse/pass/metadataschema/SchemaInstance.java
@@ -21,13 +21,12 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The SchemaInstance class represents a schema map, read from a schema URI that is fetched by the
@@ -37,19 +36,17 @@ import org.springframework.beans.factory.annotation.Autowired;
  */
 public class SchemaInstance implements Comparable<SchemaInstance> {
 
-    private JsonNode schema;
-    private HashMap<String, String> deps = new HashMap<String, String>();
-    private HashMap<String, String> refs = new HashMap<String, String>();
-    private String keyRef = "$ref";
-    private String schema_name;
-    private String schema_dir;
-    private static final Logger logger = Logger.getLogger(SchemaInstance.class.getName());
-    @Autowired
-    private SchemaFetcher schemaFetcher;
+    private final JsonNode schema;
+    private final HashMap<String, String> deps = new HashMap<>();
+    private final HashMap<String, String> refs = new HashMap<>();
+    private final String keyRef = "$ref";
+    private final String schema_name;
+    private final String schema_dir;
+    private static final Logger LOG = LoggerFactory.getLogger(SchemaFetcher.class);
 
     // all dependencies of a schema on other schemas, as well as dependencies of the
     // schemas with "greater" value than the given schema
-    private static Map<String, Collection<String>> orderedDeps = new HashMap<String, Collection<String>>();
+    private static final Map<String, Collection<String>> orderedDeps = new HashMap<>();
 
     /**
      * Constructor for SchemaInstance
@@ -177,10 +174,8 @@ public class SchemaInstance implements Comparable<SchemaInstance> {
                 JsonNode ext_schema = null;
                 try {
                     ext_schema = SchemaFetcher.getLocalSchema("/" + schema_dir + "/" + refParts[0]);
-                } catch (IllegalArgumentException e) {
-                    logger.log(Level.SEVERE, "Invalid Schema URI", e);
-                } catch (IOException e) {
-                    logger.log(Level.SEVERE, "Failed to dereference schema", e);
+                } catch (IllegalArgumentException | IOException e) {
+                    LOG.error("Invalid Schema URI", e);
                 }
                 if (refParts.length == 2) {
                     replacement = resolveRef(refParts[1], ext_schema);

--- a/pass-core-metadataschema-service/src/main/java/org/eclipse/pass/metadataschema/SchemaInstance.java
+++ b/pass-core-metadataschema-service/src/main/java/org/eclipse/pass/metadataschema/SchemaInstance.java
@@ -174,8 +174,10 @@ public class SchemaInstance implements Comparable<SchemaInstance> {
                 JsonNode ext_schema = null;
                 try {
                     ext_schema = SchemaFetcher.getLocalSchema("/" + schema_dir + "/" + refParts[0]);
-                } catch (IllegalArgumentException | IOException e) {
+                } catch (IllegalArgumentException e) {
                     LOG.error("Invalid Schema URI", e);
+                } catch (IOException e) {
+                    LOG.error("Failed to dereference schema", e);
                 }
                 if (refParts.length == 2) {
                     replacement = resolveRef(refParts[1], ext_schema);

--- a/pass-core-metadataschema-service/src/main/java/org/eclipse/pass/metadataschema/SchemaInstance.java
+++ b/pass-core-metadataschema-service/src/main/java/org/eclipse/pass/metadataschema/SchemaInstance.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
  * @see SchemaFetcher
  */
 public class SchemaInstance implements Comparable<SchemaInstance> {
-    private static final Logger LOG = LoggerFactory.getLogger(SchemaFetcher.class);
+    private static final Logger LOG = LoggerFactory.getLogger(SchemaInstance.class);
 
     private final JsonNode schema;
     private final HashMap<String, String> deps = new HashMap<>();
@@ -150,7 +150,7 @@ public class SchemaInstance implements Comparable<SchemaInstance> {
      *
      * @param node the node that is being searched for references
      */
-    public void dereference(JsonNode node) {
+    public void dereference(JsonNode node, SchemaFetcher schemaFetcher) {
         //collect all $refs in a hashmap in the schema and the xPath to the $ref
         HashMap<String, String> allRefs = new HashMap<>();
         getRefAndPointerToObject("", allRefs, node);
@@ -173,7 +173,7 @@ public class SchemaInstance implements Comparable<SchemaInstance> {
             } else { //external reference
                 JsonNode ext_schema = null;
                 try {
-                    ext_schema = SchemaFetcher.getLocalSchema("/" + schema_dir + "/" + refParts[0]);
+                    ext_schema = schemaFetcher.getLocalSchema("/" + schema_dir + "/" + refParts[0]);
                 } catch (IllegalArgumentException e) {
                     LOG.error("Invalid Schema URI", e);
                 } catch (IOException e) {

--- a/pass-core-metadataschema-service/src/main/java/org/eclipse/pass/metadataschema/SchemaInstance.java
+++ b/pass-core-metadataschema-service/src/main/java/org/eclipse/pass/metadataschema/SchemaInstance.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
  * @see SchemaFetcher
  */
 public class SchemaInstance implements Comparable<SchemaInstance> {
+    private static final Logger LOG = LoggerFactory.getLogger(SchemaFetcher.class);
 
     private final JsonNode schema;
     private final HashMap<String, String> deps = new HashMap<>();
@@ -42,7 +43,6 @@ public class SchemaInstance implements Comparable<SchemaInstance> {
     private final String keyRef = "$ref";
     private final String schema_name;
     private final String schema_dir;
-    private static final Logger LOG = LoggerFactory.getLogger(SchemaFetcher.class);
 
     // all dependencies of a schema on other schemas, as well as dependencies of the
     // schemas with "greater" value than the given schema

--- a/pass-core-metadataschema-service/src/main/java/org/eclipse/pass/metadataschema/SchemaService.java
+++ b/pass-core-metadataschema-service/src/main/java/org/eclipse/pass/metadataschema/SchemaService.java
@@ -28,32 +28,24 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.eclipse.pass.object.PassClient;
+import org.springframework.stereotype.Service;
 
 /**
  * The SchemaService class handles the business logic of the metadata schema
  * service. It can be used to get a merged schema composed of all the schemas
  * relevant to the repositories that a PASS submission must be published to.
  */
+@Service
 public class SchemaService {
 
-    private PassClient passClient;
-    private SchemaFetcher schemaFetcher;
+    private final SchemaFetcher schemaFetcher;
 
     /**
-     * SchemaService constructor
+     * Constructor for SchemaService
+     * @param schemaFetcher the component responsible for reading schemas
      */
-    public SchemaService() {
-    }
-
-    /**
-     * SchemaService constructor used in unit tests for inserting a mock client
-     * @param client PassClient for the SchemaService to use
-     */
-    public SchemaService(PassClient client) {
-        this.passClient = client;
-        schemaFetcher = new SchemaFetcher(passClient);
-
+    public SchemaService(SchemaFetcher schemaFetcher) {
+        this.schemaFetcher = schemaFetcher;
     }
 
     /**
@@ -67,22 +59,13 @@ public class SchemaService {
      * @throws IOException, if the schemas cannot be fetched
      */
     JsonNode getMergedSchema(List<String> repository_list) throws MergeFailException, IOException {
-
-        // Create a SchemaFetcher instance to get the schemas from the repository URIs
-        List<JsonNode> repository_schemas;
-        repository_schemas = schemaFetcher.getSchemas(repository_list);
-        JsonNode mergedSchema;
-        mergedSchema = mergeSchemas(repository_schemas);
-
-        return mergedSchema;
+        List<JsonNode> repository_schemas = schemaFetcher.getSchemas(repository_list);
+        return mergeSchemas(repository_schemas);
     }
 
     List<JsonNode> getIndividualSchemas(List<String> repository_list)
             throws IllegalArgumentException, URISyntaxException, IOException {
-        SchemaFetcher f = new SchemaFetcher(passClient);
-        List<JsonNode> repository_schemas;
-        repository_schemas = f.getSchemas(repository_list);
-        return repository_schemas;
+        return schemaFetcher.getSchemas(repository_list);
     }
 
     /**

--- a/pass-core-metadataschema-service/src/test/java/org/eclipse/pass/metadataschema/PassSchemaServiceControllerTest.java
+++ b/pass-core-metadataschema-service/src/test/java/org/eclipse/pass/metadataschema/PassSchemaServiceControllerTest.java
@@ -17,7 +17,9 @@
 package org.eclipse.pass.metadataschema;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.eclipse.pass.metadataschema.SchemaTestUtils.RefreshableElideMocked;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
@@ -32,7 +34,6 @@ import java.util.List;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import org.eclipse.pass.object.PassClient;
 import org.eclipse.pass.object.model.Repository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,9 +41,9 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.http.ResponseEntity;
 
-class SchemaControllerTest {
+class PassSchemaServiceControllerTest {
     private PassSchemaServiceController schemaServiceController;
-    private PassClient passClientMock;
+    private RefreshableElideMocked refreshableElideMocked;
     private Repository repositoryMock1;
     private Repository repositoryMock2;
     private final PrintStream standardOut = System.out;
@@ -50,10 +51,12 @@ class SchemaControllerTest {
 
     @BeforeEach
     void setup() {
-        passClientMock = Mockito.mock(PassClient.class);
         repositoryMock1 = Mockito.mock(Repository.class);
         repositoryMock2 = Mockito.mock(Repository.class);
-        schemaServiceController = new PassSchemaServiceController(passClientMock);
+        refreshableElideMocked = SchemaTestUtils.getMockedRefreshableElide();
+        SchemaFetcher schemaFetcher = new SchemaFetcher(refreshableElideMocked.getRefreshableElideMock());
+        SchemaService schemaService = new SchemaService(schemaFetcher);
+        schemaServiceController = new PassSchemaServiceController(schemaService);
         System.setOut(new PrintStream(outputStreamCaptor));
     }
 
@@ -84,8 +87,10 @@ class SchemaControllerTest {
 
     @Test
     void getSchemaMergeTrueTest() throws Exception {
-        when(passClientMock.getObject(Repository.class, 1L)).thenReturn(repositoryMock1);
-        when(passClientMock.getObject(Repository.class, 2L)).thenReturn(repositoryMock2);
+        when(refreshableElideMocked.getDataStoreTransactionMock().loadObject(any(), eq(1L), any()))
+                .thenReturn(repositoryMock1);
+        when(refreshableElideMocked.getDataStoreTransactionMock().loadObject(any(), eq(2L), any()))
+                .thenReturn(repositoryMock2);
 
         List<URI> r1_schemas_list = Arrays.asList(new URI("http://example.org/metadata-schemas/jhu/schema1.json"),
                 new URI("http://example.org/metadata-schemas/jhu/schema2.json"),
@@ -114,8 +119,10 @@ class SchemaControllerTest {
 
     @Test
     void getSchemaMergeTrueJhuSchemaTest() throws Exception {
-        when(passClientMock.getObject(Repository.class, 1L)).thenReturn(repositoryMock1);
-        when(passClientMock.getObject(Repository.class, 2L)).thenReturn(repositoryMock2);
+        when(refreshableElideMocked.getDataStoreTransactionMock().loadObject(any(), eq(1L), any()))
+                .thenReturn(repositoryMock1);
+        when(refreshableElideMocked.getDataStoreTransactionMock().loadObject(any(), eq(2L), any()))
+                .thenReturn(repositoryMock2);
 
         List<URI> r1_schemas_list = Arrays.asList(new URI("http://example.org/metadata-schemas/jhu/jscholarship.json"),
                 new URI("http://example.org/metadata-schemas/jhu/common.json"));
@@ -138,8 +145,10 @@ class SchemaControllerTest {
 
     @Test
     void getSchemaMergeFalseTest() throws Exception {
-        when(passClientMock.getObject(Repository.class, 1L)).thenReturn(repositoryMock1);
-        when(passClientMock.getObject(Repository.class, 2L)).thenReturn(repositoryMock2);
+        when(refreshableElideMocked.getDataStoreTransactionMock().loadObject(any(), eq(1L), any()))
+                .thenReturn(repositoryMock1);
+        when(refreshableElideMocked.getDataStoreTransactionMock().loadObject(any(), eq(2L), any()))
+                .thenReturn(repositoryMock2);
 
         List<URI> r1_schemas_list = Arrays.asList(new URI("http://example.org/metadata-schemas/jhu/schema1.json"),
                 new URI("http://example.org/metadata-schemas/jhu/schema2.json"));

--- a/pass-core-metadataschema-service/src/test/java/org/eclipse/pass/metadataschema/PassSchemaServiceControllerTest.java
+++ b/pass-core-metadataschema-service/src/test/java/org/eclipse/pass/metadataschema/PassSchemaServiceControllerTest.java
@@ -16,10 +16,12 @@
  */
 package org.eclipse.pass.metadataschema;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
 import static org.eclipse.pass.metadataschema.SchemaTestUtils.RefreshableElideMocked;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
@@ -38,7 +40,6 @@ import org.eclipse.pass.object.model.Repository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.http.ResponseEntity;
 
 class PassSchemaServiceControllerTest {
@@ -51,8 +52,8 @@ class PassSchemaServiceControllerTest {
 
     @BeforeEach
     void setup() {
-        repositoryMock1 = Mockito.mock(Repository.class);
-        repositoryMock2 = Mockito.mock(Repository.class);
+        repositoryMock1 = mock(Repository.class);
+        repositoryMock2 = mock(Repository.class);
         refreshableElideMocked = SchemaTestUtils.getMockedRefreshableElide();
         SchemaFetcher schemaFetcher = new SchemaFetcher(refreshableElideMocked.getRefreshableElideMock());
         SchemaService schemaService = new SchemaService(schemaFetcher);

--- a/pass-core-metadataschema-service/src/test/java/org/eclipse/pass/metadataschema/SchemaControllerTest.java
+++ b/pass-core-metadataschema-service/src/test/java/org/eclipse/pass/metadataschema/SchemaControllerTest.java
@@ -17,11 +17,9 @@
 package org.eclipse.pass.metadataschema;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.PrintStream;
@@ -30,9 +28,6 @@ import java.io.StringReader;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
-import javax.servlet.ReadListener;
-import javax.servlet.ServletInputStream;
-import javax.servlet.http.HttpServletRequest;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -43,12 +38,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 
 class SchemaControllerTest {
-    private static final Logger LOG = LoggerFactory.getLogger(PassSchemaServiceController.class);
     private PassSchemaServiceController schemaServiceController;
     private PassClient passClientMock;
     private Repository repositoryMock1;
@@ -74,8 +66,8 @@ class SchemaControllerTest {
     void readTextTest() throws Exception {
         String text_list = "http://example.org/foo1" + "\nhttp://example.org/bar1" + "\nhttp://example.org/foo2"
                 + "\nhttp://example.org/bar2";
-        List<String> expected = Arrays.asList(new String[] { "http://example.org/foo1", "http://example.org/bar1",
-            "http://example.org/foo2", "http://example.org/bar2" });
+        List<String> expected = Arrays.asList("http://example.org/foo1", "http://example.org/bar1",
+                "http://example.org/foo2", "http://example.org/bar2");
         Reader text_string = new StringReader(text_list);
         BufferedReader text_bufferedReader = new BufferedReader(text_string);
         assertEquals(expected, schemaServiceController.readText(text_bufferedReader));
@@ -84,39 +76,14 @@ class SchemaControllerTest {
     @Test
     void readJsonTest() throws Exception {
         String json_list = "[\"http://example.org/foo\", \"http://example.org/bar\"]";
-        List<String> expected = Arrays.asList(new String[] { "http://example.org/foo", "http://example.org/bar" });
+        List<String> expected = Arrays.asList("http://example.org/foo", "http://example.org/bar");
         Reader json_string = new StringReader(json_list);
         BufferedReader json_bufferedReader = new BufferedReader(json_string);
         assertEquals(expected, schemaServiceController.readJson(json_bufferedReader));
     }
 
-    private ServletInputStream createServletInputStream(ByteArrayInputStream in) {
-        return new ServletInputStream() {
-            @Override
-            public boolean isFinished() {
-                return false;
-            }
-
-            @Override
-            public boolean isReady() {
-                return false;
-            }
-
-            @Override
-            public void setReadListener(ReadListener readListener) {
-            }
-
-            @Override
-            public int read() {
-                return in.read();
-            }
-        };
-    }
-
     @Test
     void getSchemaMergeTrueTest() throws Exception {
-        HttpServletRequest request = mock(HttpServletRequest.class);
-
         when(passClientMock.getObject(Repository.class, 1L)).thenReturn(repositoryMock1);
         when(passClientMock.getObject(Repository.class, 2L)).thenReturn(repositoryMock2);
 
@@ -147,8 +114,6 @@ class SchemaControllerTest {
 
     @Test
     void getSchemaMergeTrueJhuSchemaTest() throws Exception {
-        HttpServletRequest request = mock(HttpServletRequest.class);
-
         when(passClientMock.getObject(Repository.class, 1L)).thenReturn(repositoryMock1);
         when(passClientMock.getObject(Repository.class, 2L)).thenReturn(repositoryMock2);
 
@@ -173,15 +138,13 @@ class SchemaControllerTest {
 
     @Test
     void getSchemaMergeFalseTest() throws Exception {
-        HttpServletRequest request = mock(HttpServletRequest.class);
-
         when(passClientMock.getObject(Repository.class, 1L)).thenReturn(repositoryMock1);
         when(passClientMock.getObject(Repository.class, 2L)).thenReturn(repositoryMock2);
 
         List<URI> r1_schemas_list = Arrays.asList(new URI("http://example.org/metadata-schemas/jhu/schema1.json"),
                 new URI("http://example.org/metadata-schemas/jhu/schema2.json"));
 
-        List<URI> r2_schemas_list = Arrays.asList(new URI("http://example.org/metadata-schemas/jhu/schema3.json"));
+        List<URI> r2_schemas_list = List.of(new URI("http://example.org/metadata-schemas/jhu/schema3.json"));
 
         when(repositoryMock1.getSchemas()).thenReturn(r1_schemas_list);
         when(repositoryMock2.getSchemas()).thenReturn(r2_schemas_list);

--- a/pass-core-metadataschema-service/src/test/java/org/eclipse/pass/metadataschema/SchemaFetcherTest.java
+++ b/pass-core-metadataschema-service/src/test/java/org/eclipse/pass/metadataschema/SchemaFetcherTest.java
@@ -16,11 +16,14 @@
  */
 package org.eclipse.pass.metadataschema;
 
+import static org.eclipse.pass.metadataschema.SchemaTestUtils.RefreshableElideMocked;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
-import static org.eclipse.pass.metadataschema.SchemaTestUtils.RefreshableElideMocked;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.InputStream;
 import java.net.URI;

--- a/pass-core-metadataschema-service/src/test/java/org/eclipse/pass/metadataschema/SchemaInstanceTest.java
+++ b/pass-core-metadataschema-service/src/test/java/org/eclipse/pass/metadataschema/SchemaInstanceTest.java
@@ -24,8 +24,10 @@ import java.util.Collections;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yahoo.elide.RefreshableElide;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 class SchemaInstanceTest {
 
@@ -131,7 +133,8 @@ class SchemaInstanceTest {
 
         SchemaInstance testSchema = new SchemaInstance(map.readTree(example_schema_json));
         SchemaInstance expectedSchema = new SchemaInstance(map.readTree(expected));
-        testSchema.dereference(testSchema.getSchema());
+        SchemaFetcher schemaFetcher = new SchemaFetcher(Mockito.mock(RefreshableElide.class));
+        testSchema.dereference(testSchema.getSchema(), schemaFetcher);
         assertEquals(expectedSchema.getSchema(), testSchema.getSchema());
     }
 
@@ -145,7 +148,8 @@ class SchemaInstanceTest {
 
         SchemaInstance testSchema = new SchemaInstance(map.readTree(schemaDerefTest));
         SchemaInstance expectedSchema = new SchemaInstance(map.readTree(expectedDeref));
-        testSchema.dereference(testSchema.getSchema());
+        SchemaFetcher schemaFetcher = new SchemaFetcher(Mockito.mock(RefreshableElide.class));
+        testSchema.dereference(testSchema.getSchema(), schemaFetcher);
         assertEquals(expectedSchema.getSchema(), testSchema.getSchema());
     }
 
@@ -159,7 +163,8 @@ class SchemaInstanceTest {
 
         SchemaInstance testSchema = new SchemaInstance(map.readTree(schemaDerefTest));
         SchemaInstance expectedSchema = new SchemaInstance(map.readTree(expectedDeref));
-        testSchema.dereference(testSchema.getSchema());
+        SchemaFetcher schemaFetcher = new SchemaFetcher(Mockito.mock(RefreshableElide.class));
+        testSchema.dereference(testSchema.getSchema(), schemaFetcher);
         assertEquals(expectedSchema.getSchema(), testSchema.getSchema());
     }
 
@@ -173,7 +178,8 @@ class SchemaInstanceTest {
 
         SchemaInstance testSchema = new SchemaInstance(map.readTree(jscholarSchemaJson));
         SchemaInstance expectedSchema = new SchemaInstance(map.readTree(jscholarExpected));
-        testSchema.dereference(testSchema.getSchema());
+        SchemaFetcher schemaFetcher = new SchemaFetcher(Mockito.mock(RefreshableElide.class));
+        testSchema.dereference(testSchema.getSchema(), schemaFetcher);
         assertEquals(expectedSchema.getSchema(), testSchema.getSchema());
     }
 
@@ -187,7 +193,8 @@ class SchemaInstanceTest {
 
         SchemaInstance testSchema = new SchemaInstance(map.readTree(jscholarSchemaJson));
         SchemaInstance expectedSchema = new SchemaInstance(map.readTree(jscholarExpected));
-        testSchema.dereference(testSchema.getSchema());
+        SchemaFetcher schemaFetcher = new SchemaFetcher(Mockito.mock(RefreshableElide.class));
+        testSchema.dereference(testSchema.getSchema(), schemaFetcher);
         assertEquals(expectedSchema.getSchema(), testSchema.getSchema());
     }
 

--- a/pass-core-metadataschema-service/src/test/java/org/eclipse/pass/metadataschema/SchemaServiceTest.java
+++ b/pass-core-metadataschema-service/src/test/java/org/eclipse/pass/metadataschema/SchemaServiceTest.java
@@ -16,11 +16,12 @@
  */
 package org.eclipse.pass.metadataschema;
 
+import static org.eclipse.pass.metadataschema.SchemaTestUtils.RefreshableElideMocked;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
-import static org.eclipse.pass.metadataschema.SchemaTestUtils.RefreshableElideMocked;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
 
 import java.io.InputStream;
 import java.net.URI;

--- a/pass-core-metadataschema-service/src/test/java/org/eclipse/pass/metadataschema/SchemaServiceTest.java
+++ b/pass-core-metadataschema-service/src/test/java/org/eclipse/pass/metadataschema/SchemaServiceTest.java
@@ -18,7 +18,9 @@ package org.eclipse.pass.metadataschema;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.eclipse.pass.metadataschema.SchemaTestUtils.RefreshableElideMocked;
 
 import java.io.InputStream;
 import java.net.URI;
@@ -27,7 +29,6 @@ import java.util.List;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.eclipse.pass.object.PassClient;
 import org.eclipse.pass.object.model.Repository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -35,7 +36,7 @@ import org.mockito.Mockito;
 
 class SchemaServiceTest {
 
-    private PassClient passClientMock;
+    private RefreshableElideMocked refreshableElideMocked;
     private Repository repositoryMock1;
     private Repository repositoryMock2;
     private SchemaService schemaService;
@@ -43,10 +44,11 @@ class SchemaServiceTest {
 
     @BeforeEach
     void setup() {
-        passClientMock = Mockito.mock(PassClient.class);
         repositoryMock1 = Mockito.mock(Repository.class);
         repositoryMock2 = Mockito.mock(Repository.class);
-        schemaService = new SchemaService(passClientMock);
+        refreshableElideMocked = SchemaTestUtils.getMockedRefreshableElide();
+        SchemaFetcher schemaFetcher = new SchemaFetcher(refreshableElideMocked.getRefreshableElideMock());
+        schemaService = new SchemaService(schemaFetcher);
         map = new ObjectMapper();
     }
 
@@ -225,8 +227,10 @@ class SchemaServiceTest {
     @Test
     void getMergedSchemaTest() throws Exception {
         List<String> repositoryIds = Arrays.asList("1", "2");
-        when(passClientMock.getObject(Repository.class, 1L)).thenReturn(repositoryMock1);
-        when(passClientMock.getObject(Repository.class, 2L)).thenReturn(repositoryMock2);
+        when(refreshableElideMocked.getDataStoreTransactionMock().loadObject(any(), eq(1L), any()))
+                .thenReturn(repositoryMock1);
+        when(refreshableElideMocked.getDataStoreTransactionMock().loadObject(any(), eq(2L), any()))
+                .thenReturn(repositoryMock2);
 
         List<URI> r1_schemas_list = Arrays.asList(new URI("https://example.com/metadata-schemas/jhu/schema1.json"),
                 new URI("https://example.com/metadata-schemas/jhu/schema2.json"),
@@ -249,10 +253,11 @@ class SchemaServiceTest {
 
     @Test
     void getMergeJscholarSchemaTest() throws Exception {
-        List<String> repositoryIds = Arrays.asList("1");
-        when(passClientMock.getObject(Repository.class, 1L)).thenReturn(repositoryMock1);
+        List<String> repositoryIds = List.of("1");
+        when(refreshableElideMocked.getDataStoreTransactionMock().loadObject(any(), eq(1L), any()))
+                .thenReturn(repositoryMock1);
 
-        List<URI> r1_schemas_list = Arrays.asList(new URI("https://example.com/metadata-schemas/jhu/jscholarship.json"));
+        List<URI> r1_schemas_list = List.of(new URI("https://example.com/metadata-schemas/jhu/jscholarship.json"));
 
         when(repositoryMock1.getSchemas()).thenReturn(r1_schemas_list);
 

--- a/pass-core-metadataschema-service/src/test/java/org/eclipse/pass/metadataschema/SchemaTestUtils.java
+++ b/pass-core-metadataschema-service/src/test/java/org/eclipse/pass/metadataschema/SchemaTestUtils.java
@@ -1,0 +1,57 @@
+package org.eclipse.pass.metadataschema;
+
+import com.yahoo.elide.Elide;
+import com.yahoo.elide.ElideSettings;
+import com.yahoo.elide.RefreshableElide;
+import com.yahoo.elide.core.datastore.DataStore;
+import com.yahoo.elide.core.datastore.DataStoreTransaction;
+import com.yahoo.elide.core.dictionary.EntityDictionary;
+
+import java.util.Set;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public final class SchemaTestUtils {
+
+    /**
+     * Returns a RefreshableElideMocked object. The RefreshableElideMocked object contains
+     * a mocked RefreshableElide that can be passed to constructors as required. It also
+     * contains a mocked DataStoreTransaction that can be used to create mocked calls for
+     * elide CRUD operations.
+     * @return a RefreshableElideMocked object
+     */
+    static RefreshableElideMocked getMockedRefreshableElide() {
+        RefreshableElide refreshableElideMock = mock(RefreshableElide.class);
+        Elide elideMock = mock(Elide.class);
+        when(refreshableElideMock.getElide()).thenReturn(elideMock);
+        ElideSettings elideSettingsMock = mock(ElideSettings.class);
+        when(elideMock.getElideSettings()).thenReturn(elideSettingsMock);
+        EntityDictionary entityDictionaryMock = mock(EntityDictionary.class);
+        when(elideSettingsMock.getDictionary()).thenReturn(entityDictionaryMock);
+        when(elideSettingsMock.getDictionary().getApiVersions()).thenReturn(Set.of("1"));
+        DataStore dataStoreMock = mock(DataStore.class);
+        when(elideMock.getDataStore()).thenReturn(dataStoreMock);
+        DataStoreTransaction dataStoreTransactionMock = mock(DataStoreTransaction.class);
+        when(dataStoreMock.beginReadTransaction()).thenReturn(dataStoreTransactionMock);
+        return new RefreshableElideMocked(refreshableElideMock, dataStoreTransactionMock);
+    }
+
+    static class RefreshableElideMocked {
+        private final RefreshableElide refreshableElideMock;
+        private final DataStoreTransaction dataStoreTransactionMock;
+
+        RefreshableElideMocked(RefreshableElide refreshableElideMock, DataStoreTransaction dataStoreTransactionMock) {
+            this.refreshableElideMock = refreshableElideMock;
+            this.dataStoreTransactionMock = dataStoreTransactionMock;
+        }
+
+        RefreshableElide getRefreshableElideMock() {
+            return refreshableElideMock;
+        }
+
+        DataStoreTransaction getDataStoreTransactionMock() {
+            return dataStoreTransactionMock;
+        }
+    }
+}

--- a/pass-core-metadataschema-service/src/test/java/org/eclipse/pass/metadataschema/SchemaTestUtils.java
+++ b/pass-core-metadataschema-service/src/test/java/org/eclipse/pass/metadataschema/SchemaTestUtils.java
@@ -1,5 +1,10 @@
 package org.eclipse.pass.metadataschema;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Set;
+
 import com.yahoo.elide.Elide;
 import com.yahoo.elide.ElideSettings;
 import com.yahoo.elide.RefreshableElide;
@@ -7,12 +12,9 @@ import com.yahoo.elide.core.datastore.DataStore;
 import com.yahoo.elide.core.datastore.DataStoreTransaction;
 import com.yahoo.elide.core.dictionary.EntityDictionary;
 
-import java.util.Set;
-
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 public final class SchemaTestUtils {
+
+    private SchemaTestUtils() {}
 
     /**
      * Returns a RefreshableElideMocked object. The RefreshableElideMocked object contains

--- a/pass-core-object-service/src/main/java/org/eclipse/pass/object/ElideDataStorePassClient.java
+++ b/pass-core-object-service/src/main/java/org/eclipse/pass/object/ElideDataStorePassClient.java
@@ -41,7 +41,7 @@ import org.eclipse.pass.object.model.PassEntity;
  * interplay between the RequestScope, PersistentResource, and
  * DataStoreTransaction. This approach means that life cycle hooks wills not be
  * called because they can only be added in PersistentResource.
- *
+ * <p>
  * Objects retrieved using this client may not work after the client has been closed.
  * This is because relationships are loaded lazily.
  */

--- a/pass-core-object-service/src/main/java/org/eclipse/pass/object/ElidePassClient.java
+++ b/pass-core-object-service/src/main/java/org/eclipse/pass/object/ElidePassClient.java
@@ -44,7 +44,7 @@ import org.eclipse.pass.object.security.WebSecurityRole;
 /**
  * PASS client which uses the HTTP verb methods of the main Elide class.
  * Hooks should be triggered and permissions will be checked.
- *
+ * <p>
  * Objects retrieved using this client may not work after the client has been closed.
  * This is because relationships are loaded lazily.
  */

--- a/pass-core-object-service/src/main/java/org/eclipse/pass/object/PassClientSelector.java
+++ b/pass-core-object-service/src/main/java/org/eclipse/pass/object/PassClientSelector.java
@@ -19,7 +19,7 @@ import org.eclipse.pass.object.model.PassEntity;
 
 /**
  * PassClientSelector is used to select objects in the repository.
- * See https://elide.io/pages/guide/v6/10-jsonapi.html for information on the
+ * See <a href="https://elide.io/pages/guide/v6/10-jsonapi.html">Elide JSON-API</a> for information on the
  * sort and filter syntax.
  */
 public class PassClientSelector<T extends PassEntity> {

--- a/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/AggregatedDepositStatus.java
+++ b/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/AggregatedDepositStatus.java
@@ -57,9 +57,9 @@ public enum AggregatedDepositStatus {
         }
     }
 
-    private String value;
+    private final String value;
 
-    private AggregatedDepositStatus(String value) {
+    AggregatedDepositStatus(String value) {
         this.value = value;
     }
 

--- a/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/AwardStatus.java
+++ b/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/AwardStatus.java
@@ -46,9 +46,9 @@ public enum AwardStatus {
         }
     }
 
-    private String value;
+    private final String value;
 
-    private AwardStatus(String value) {
+    AwardStatus(String value) {
         this.value = value;
     }
 

--- a/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/ContributorRole.java
+++ b/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/ContributorRole.java
@@ -51,9 +51,9 @@ public enum ContributorRole {
         }
     }
 
-    private String value;
+    private final String value;
 
-    private ContributorRole(String value) {
+    ContributorRole(String value) {
         this.value = value;
     }
 

--- a/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/CopyStatus.java
+++ b/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/CopyStatus.java
@@ -52,9 +52,9 @@ public enum CopyStatus {
         }
     }
 
-    private String value;
+    private final String value;
 
-    private CopyStatus(String value) {
+    CopyStatus(String value) {
         this.value = value;
     }
 

--- a/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/DepositStatus.java
+++ b/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/DepositStatus.java
@@ -49,9 +49,9 @@ public enum DepositStatus {
         }
     }
 
-    private String value;
+    private final String value;
 
-    private DepositStatus(String value) {
+    DepositStatus(String value) {
         this.value = value;
     }
 

--- a/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/EventType.java
+++ b/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/EventType.java
@@ -60,9 +60,9 @@ public enum EventType {
         }
     }
 
-    String value;
+    private final String value;
 
-    private EventType(String value) {
+    EventType(String value) {
         this.value = value;
     }
 

--- a/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/FileRole.java
+++ b/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/FileRole.java
@@ -50,9 +50,9 @@ public enum FileRole {
         }
     }
 
-    private String value;
+    private final String value;
 
-    private FileRole(String value) {
+    FileRole(String value) {
         this.value = value;
     }
 

--- a/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/IntegrationType.java
+++ b/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/IntegrationType.java
@@ -43,9 +43,9 @@ public enum IntegrationType {
         }
     }
 
-    private String value;
+    private final String value;
 
-    private IntegrationType(String value) {
+    IntegrationType(String value) {
         this.value = value;
     }
 

--- a/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/PerformerRole.java
+++ b/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/PerformerRole.java
@@ -28,9 +28,9 @@ public enum PerformerRole {
      */
     SUBMITTER("submitter");
 
-    private String value;
+    private final String value;
 
-    private PerformerRole(String value) {
+    PerformerRole(String value) {
         this.value = value;
     }
 

--- a/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/PmcParticipation.java
+++ b/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/PmcParticipation.java
@@ -16,7 +16,8 @@
 package org.eclipse.pass.object.model;
 
 /**
- * PMC route options. Full documentation here: https://publicaccess.nih.gov/submit_process.htm
+ * PMC route options. Full documentation here:
+ * <a href="https://publicaccess.nih.gov/submit_process.htm">Submit Process</a>
  *
  * @author Karen Hanson
  */

--- a/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/RepositoryCopy.java
+++ b/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/RepositoryCopy.java
@@ -42,7 +42,7 @@ public class RepositoryCopy extends PassEntity {
      * IDs assigned by the repository
      */
     @Convert(converter = ListToStringConverter.class)
-    private List<String> externalIds = new ArrayList<String>();
+    private List<String> externalIds = new ArrayList<>();
 
     /**
      * Status of deposit
@@ -80,7 +80,7 @@ public class RepositoryCopy extends PassEntity {
      */
     public RepositoryCopy(RepositoryCopy repositoryCopy) {
         super(repositoryCopy);
-        this.externalIds = new ArrayList<String>(repositoryCopy.externalIds);
+        this.externalIds = new ArrayList<>(repositoryCopy.externalIds);
         this.copyStatus = repositoryCopy.copyStatus;
         this.accessUrl = repositoryCopy.accessUrl;
         this.publication = repositoryCopy.publication;

--- a/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/Source.java
+++ b/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/Source.java
@@ -15,9 +15,9 @@ public enum Source {
      */
     OTHER("other");
 
-    private String value;
+    private final String value;
 
-    private Source(String value) {
+    Source(String value) {
         this.value = value;
     }
 

--- a/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/SubmissionStatus.java
+++ b/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/SubmissionStatus.java
@@ -84,11 +84,11 @@ public enum SubmissionStatus {
         }
     }
 
-    private String value;
+    private final String value;
 
-    private boolean submitted;
+    private final boolean submitted;
 
-    private SubmissionStatus(String value, boolean submitted) {
+    SubmissionStatus(String value, boolean submitted) {
         this.value = value;
         this.submitted = submitted;
     }

--- a/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/UserRole.java
+++ b/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/UserRole.java
@@ -41,9 +41,9 @@ public enum UserRole {
         }
     }
 
-    private String value;
+    private final String value;
 
-    private UserRole(String value) {
+    UserRole(String value) {
         this.value = value;
     }
 

--- a/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/ContributorModelTests.java
+++ b/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/ContributorModelTests.java
@@ -16,7 +16,8 @@
 package org.eclipse.pass.object.model;
 
 import static org.eclipse.pass.object.model.support.TestObjectCreator.createContributor;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import org.eclipse.pass.object.model.support.TestValues;
 import org.junit.jupiter.api.Test;

--- a/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/ContributorModelTests.java
+++ b/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/ContributorModelTests.java
@@ -16,8 +16,7 @@
 package org.eclipse.pass.object.model;
 
 import static org.eclipse.pass.object.model.support.TestObjectCreator.createContributor;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.eclipse.pass.object.model.support.TestValues;
 import org.junit.jupiter.api.Test;
@@ -38,7 +37,7 @@ public class ContributorModelTests {
         assertEquals(contributor1.hashCode(), contributor2.hashCode());
 
         contributor1.setFirstName("different");
-        assertTrue(!contributor1.equals(contributor2));
+        assertNotEquals(contributor1, contributor2);
     }
 
     /**
@@ -55,14 +54,14 @@ public class ContributorModelTests {
         assertEquals(TestValues.USER_EMAIL, contributor.getEmail());
         assertEquals(newEmail, contributorCopy.getEmail());
 
-        contributorCopy.setUser(createUser(TestValues.USER_ID_2));
+        contributorCopy.setUser(createUser());
         assertEquals(TestValues.USER_ID_1, contributor.getUser().getId());
         assertEquals(TestValues.USER_ID_2, contributorCopy.getUser().getId());
     }
 
-    private User createUser(Long id) {
+    private User createUser() {
         User user = new User();
-        user.setId(id);
+        user.setId(TestValues.USER_ID_2);
         user.setFirstName(TestValues.USER_FIRST_NAME);
         user.setMiddleName(TestValues.USER_MIDDLE_NAME);
         user.setLastName(TestValues.USER_LAST_NAME);

--- a/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/DepositModelTests.java
+++ b/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/DepositModelTests.java
@@ -16,7 +16,8 @@
 package org.eclipse.pass.object.model;
 
 import static org.eclipse.pass.object.model.support.TestObjectCreator.createDeposit;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import org.eclipse.pass.object.model.support.TestValues;
 import org.junit.jupiter.api.Test;

--- a/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/DepositModelTests.java
+++ b/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/DepositModelTests.java
@@ -16,8 +16,7 @@
 package org.eclipse.pass.object.model;
 
 import static org.eclipse.pass.object.model.support.TestObjectCreator.createDeposit;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.eclipse.pass.object.model.support.TestValues;
 import org.junit.jupiter.api.Test;
@@ -39,7 +38,7 @@ public class DepositModelTests {
         assertEquals(deposit1.hashCode(), deposit2.hashCode());
 
         deposit1.setDepositStatusRef("different");
-        assertTrue(!deposit1.equals(deposit2));
+        assertNotEquals(deposit1, deposit2);
     }
 
     /**

--- a/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/FileModelTests.java
+++ b/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/FileModelTests.java
@@ -16,7 +16,8 @@
 package org.eclipse.pass.object.model;
 
 import static org.eclipse.pass.object.model.support.TestObjectCreator.createSubmission;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.net.URI;
 

--- a/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/FileModelTests.java
+++ b/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/FileModelTests.java
@@ -16,8 +16,7 @@
 package org.eclipse.pass.object.model;
 
 import static org.eclipse.pass.object.model.support.TestObjectCreator.createSubmission;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.net.URI;
 
@@ -41,7 +40,7 @@ public class FileModelTests {
         assertEquals(file1.hashCode(), file2.hashCode());
 
         file1.setDescription("different");
-        assertTrue(!file1.equals(file2));
+        assertNotEquals(file1, file2);
     }
 
     /**

--- a/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/FunderModelTests.java
+++ b/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/FunderModelTests.java
@@ -16,8 +16,7 @@
 package org.eclipse.pass.object.model;
 
 import static org.eclipse.pass.object.model.support.TestObjectCreator.createFunder;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.net.URI;
 
@@ -40,7 +39,7 @@ public class FunderModelTests {
         assertEquals(funder1.hashCode(), funder2.hashCode());
 
         funder1.setName("different");
-        assertTrue(!funder1.equals(funder2));
+        assertNotEquals(funder1, funder2);
     }
 
     /**

--- a/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/FunderModelTests.java
+++ b/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/FunderModelTests.java
@@ -16,7 +16,8 @@
 package org.eclipse.pass.object.model;
 
 import static org.eclipse.pass.object.model.support.TestObjectCreator.createFunder;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.net.URI;
 

--- a/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/GrantModelTests.java
+++ b/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/GrantModelTests.java
@@ -16,8 +16,7 @@
 package org.eclipse.pass.object.model;
 
 import static org.eclipse.pass.object.model.support.TestObjectCreator.createGrant;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.time.ZonedDateTime;
 
@@ -41,7 +40,7 @@ public class GrantModelTests {
         assertEquals(grant1.hashCode(), grant2.hashCode());
 
         grant1.setAwardNumber("different");
-        assertTrue(!grant1.equals(grant2));
+        assertNotEquals(grant1, grant2);
     }
 
     /**

--- a/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/GrantModelTests.java
+++ b/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/GrantModelTests.java
@@ -16,7 +16,8 @@
 package org.eclipse.pass.object.model;
 
 import static org.eclipse.pass.object.model.support.TestObjectCreator.createGrant;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.time.ZonedDateTime;
 

--- a/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/JournalModelTests.java
+++ b/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/JournalModelTests.java
@@ -16,7 +16,8 @@
 package org.eclipse.pass.object.model;
 
 import static org.eclipse.pass.object.model.support.TestObjectCreator.createJournal;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/JournalModelTests.java
+++ b/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/JournalModelTests.java
@@ -16,8 +16,7 @@
 package org.eclipse.pass.object.model;
 
 import static org.eclipse.pass.object.model.support.TestObjectCreator.createJournal;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -42,7 +41,7 @@ public class JournalModelTests {
         assertEquals(journal1.hashCode(), journal2.hashCode());
 
         journal1.setJournalName("different");
-        assertTrue(!journal1.equals(journal2));
+        assertNotEquals(journal1, journal2);
     }
 
     /**
@@ -51,7 +50,7 @@ public class JournalModelTests {
     @Test
     public void testJournalCopyConstructor()  {
         Journal journal = createJournal(TestValues.JOURNAL_ID_1);
-        List<String> issnsOrig = new ArrayList<String>(
+        List<String> issnsOrig = new ArrayList<>(
             Arrays.asList(TestValues.JOURNAL_ISSN_1, TestValues.JOURNAL_ISSN_2));
         journal.setIssns(issnsOrig);
         Journal journalCopy = new Journal(journal);
@@ -62,7 +61,7 @@ public class JournalModelTests {
         assertEquals(PmcParticipation.valueOf(TestValues.JOURNAL_PMCPARTICIPATION), journal.getPmcParticipation());
         assertEquals(PmcParticipation.A, journalCopy.getPmcParticipation());
 
-        List<String> issnsNew = new ArrayList<String>(Arrays.asList("9876-1234"));
+        List<String> issnsNew = List.of("9876-1234");
         journalCopy.setIssns(issnsNew);
         assertEquals(issnsOrig, journal.getIssns());
         assertEquals(issnsNew, journalCopy.getIssns());

--- a/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/PolicyModelTests.java
+++ b/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/PolicyModelTests.java
@@ -17,7 +17,8 @@ package org.eclipse.pass.object.model;
 
 import static org.eclipse.pass.object.model.support.TestObjectCreator.createPolicy;
 import static org.eclipse.pass.object.model.support.TestObjectCreator.createRepository;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.net.URI;
 import java.util.ArrayList;

--- a/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/PolicyModelTests.java
+++ b/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/PolicyModelTests.java
@@ -17,8 +17,7 @@ package org.eclipse.pass.object.model;
 
 import static org.eclipse.pass.object.model.support.TestObjectCreator.createPolicy;
 import static org.eclipse.pass.object.model.support.TestObjectCreator.createRepository;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.net.URI;
 import java.util.ArrayList;
@@ -44,7 +43,7 @@ public class PolicyModelTests {
         assertEquals(policy1.hashCode(), policy2.hashCode());
 
         policy1.setPolicyUrl(URI.create("https://somethingdifferent.test"));
-        assertTrue(!policy1.equals(policy2));
+        assertNotEquals(policy1, policy2);
     }
 
     /**
@@ -54,7 +53,7 @@ public class PolicyModelTests {
     public void testPolicyCopyConstructor()  {
         Policy policy = createPolicy(TestValues.POLICY_ID_1);
         List<Repository> repositoriesOrig =
-            new ArrayList<Repository>(Arrays.asList(createRepository(TestValues.REPOSITORY_ID_1),
+            new ArrayList<>(Arrays.asList(createRepository(TestValues.REPOSITORY_ID_1),
                                              createRepository(TestValues.REPOSITORY_ID_2)));
         policy.setRepositories(repositoriesOrig);
 
@@ -66,8 +65,7 @@ public class PolicyModelTests {
         assertEquals(URI.create(TestValues.INSTITUTION_ID_1), policy.getInstitution());
         assertEquals(newInstitution, policyCopy.getInstitution());
 
-        List<Repository> repositoriesNew =
-            new ArrayList<Repository>(Arrays.asList(createRepository(TestValues.REPOSITORY_ID_2)));
+        List<Repository> repositoriesNew = List.of(createRepository(TestValues.REPOSITORY_ID_2));
         policyCopy.setRepositories(repositoriesNew);
         assertEquals(repositoriesOrig, policy.getRepositories());
         assertEquals(repositoriesNew, policyCopy.getRepositories());

--- a/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/PublicationModelTests.java
+++ b/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/PublicationModelTests.java
@@ -16,8 +16,7 @@
 package org.eclipse.pass.object.model;
 
 import static org.eclipse.pass.object.model.support.TestObjectCreator.createPublication;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.eclipse.pass.object.model.support.TestValues;
 import org.junit.jupiter.api.Test;
@@ -38,7 +37,7 @@ public class PublicationModelTests {
         assertEquals(publication1.hashCode(), publication2.hashCode());
 
         publication1.setIssue("different");
-        assertTrue(!publication1.equals(publication2));
+        assertNotEquals(publication1, publication2);
     }
 
     /**

--- a/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/PublicationModelTests.java
+++ b/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/PublicationModelTests.java
@@ -16,7 +16,8 @@
 package org.eclipse.pass.object.model;
 
 import static org.eclipse.pass.object.model.support.TestObjectCreator.createPublication;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import org.eclipse.pass.object.model.support.TestValues;
 import org.junit.jupiter.api.Test;

--- a/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/PublisherModelTests.java
+++ b/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/PublisherModelTests.java
@@ -16,8 +16,7 @@
 package org.eclipse.pass.object.model;
 
 import static org.eclipse.pass.object.model.support.TestObjectCreator.createPublisher;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.eclipse.pass.object.model.support.TestValues;
 import org.junit.jupiter.api.Test;
@@ -38,7 +37,7 @@ public class PublisherModelTests {
         assertEquals(publisher1.hashCode(), publisher2.hashCode());
 
         publisher1.setName("different");
-        assertTrue(!publisher1.equals(publisher2));
+        assertNotEquals(publisher1, publisher2);
     }
 
     /**

--- a/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/PublisherModelTests.java
+++ b/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/PublisherModelTests.java
@@ -16,7 +16,8 @@
 package org.eclipse.pass.object.model;
 
 import static org.eclipse.pass.object.model.support.TestObjectCreator.createPublisher;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import org.eclipse.pass.object.model.support.TestValues;
 import org.junit.jupiter.api.Test;

--- a/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/RepositoryCopyModelTests.java
+++ b/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/RepositoryCopyModelTests.java
@@ -18,8 +18,7 @@ package org.eclipse.pass.object.model;
 import static org.eclipse.pass.object.model.support.TestObjectCreator.createPublication;
 import static org.eclipse.pass.object.model.support.TestObjectCreator.createRepository;
 import static org.eclipse.pass.object.model.support.TestObjectCreator.createRepositoryCopy;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -44,7 +43,7 @@ public class RepositoryCopyModelTests {
         assertEquals(repoCopy1.hashCode(), repoCopy2.hashCode());
 
         repoCopy1.setRepository(createRepository(TestValues.REPOSITORY_ID_2));
-        assertTrue(!repoCopy1.equals(repoCopy2));
+        assertNotEquals(repoCopy1, repoCopy2);
     }
 
     /**
@@ -53,7 +52,7 @@ public class RepositoryCopyModelTests {
     @Test
     public void testRepositoryCopyCopyConstructor()  {
         RepositoryCopy repositoryCopy = createRepositoryCopy(TestValues.REPOSITORYCOPY_ID_1);
-        List<String> externalIds = new ArrayList<String>(
+        List<String> externalIds = new ArrayList<>(
             Arrays.asList(TestValues.REPOSITORYCOPY_EXTERNALID_1, TestValues.REPOSITORYCOPY_EXTERNALID_2));
         repositoryCopy.setExternalIds(externalIds);
         RepositoryCopy repositoryCopyCopy = new RepositoryCopy(repositoryCopy);
@@ -64,7 +63,7 @@ public class RepositoryCopyModelTests {
         assertEquals(createPublication(TestValues.PUBLICATION_ID_1), repositoryCopy.getPublication());
         assertEquals(newPublication, repositoryCopyCopy.getPublication());
 
-        List<String> externalIdsNew = new ArrayList<String>(Arrays.asList(TestValues.REPOSITORYCOPY_EXTERNALID_2));
+        List<String> externalIdsNew = List.of(TestValues.REPOSITORYCOPY_EXTERNALID_2);
         repositoryCopyCopy.setExternalIds(externalIdsNew);
         assertEquals(externalIds, repositoryCopy.getExternalIds());
         assertEquals(externalIdsNew, repositoryCopyCopy.getExternalIds());

--- a/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/RepositoryCopyModelTests.java
+++ b/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/RepositoryCopyModelTests.java
@@ -18,7 +18,8 @@ package org.eclipse.pass.object.model;
 import static org.eclipse.pass.object.model.support.TestObjectCreator.createPublication;
 import static org.eclipse.pass.object.model.support.TestObjectCreator.createRepository;
 import static org.eclipse.pass.object.model.support.TestObjectCreator.createRepositoryCopy;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/RepositoryModelTests.java
+++ b/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/RepositoryModelTests.java
@@ -16,8 +16,7 @@
 package org.eclipse.pass.object.model;
 
 import static org.eclipse.pass.object.model.support.TestObjectCreator.createRepository;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.eclipse.pass.object.model.support.TestValues;
 import org.junit.jupiter.api.Test;
@@ -38,7 +37,7 @@ public class RepositoryModelTests {
         assertEquals(repository1.hashCode(), repository2.hashCode());
 
         repository1.setName("different");
-        assertTrue(!repository1.equals(repository2));
+        assertNotEquals(repository1, repository2);
     }
 
     /**

--- a/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/RepositoryModelTests.java
+++ b/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/RepositoryModelTests.java
@@ -16,7 +16,8 @@
 package org.eclipse.pass.object.model;
 
 import static org.eclipse.pass.object.model.support.TestObjectCreator.createRepository;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import org.eclipse.pass.object.model.support.TestValues;
 import org.junit.jupiter.api.Test;

--- a/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/SubmissionEventModelTests.java
+++ b/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/SubmissionEventModelTests.java
@@ -17,8 +17,7 @@ package org.eclipse.pass.object.model;
 
 import static org.eclipse.pass.object.model.support.TestObjectCreator.createSubmission;
 import static org.eclipse.pass.object.model.support.TestObjectCreator.createUser;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.net.URI;
 import java.time.ZonedDateTime;
@@ -43,7 +42,7 @@ public class SubmissionEventModelTests {
         assertEquals(submissionEvent1.hashCode(), submissionEvent2.hashCode());
 
         submissionEvent1.setPerformerRole(PerformerRole.SUBMITTER);
-        assertTrue(!submissionEvent1.equals(submissionEvent2));
+        assertNotEquals(submissionEvent1, submissionEvent2);
     }
 
     /**

--- a/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/SubmissionEventModelTests.java
+++ b/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/SubmissionEventModelTests.java
@@ -17,7 +17,8 @@ package org.eclipse.pass.object.model;
 
 import static org.eclipse.pass.object.model.support.TestObjectCreator.createSubmission;
 import static org.eclipse.pass.object.model.support.TestObjectCreator.createUser;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.net.URI;
 import java.time.ZonedDateTime;

--- a/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/SubmissionModelTests.java
+++ b/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/SubmissionModelTests.java
@@ -17,7 +17,10 @@ package org.eclipse.pass.object.model;
 
 import static org.eclipse.pass.object.model.support.TestObjectCreator.createSubmission;
 import static org.eclipse.pass.object.model.support.TestObjectCreator.createUser;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/SubmissionModelTests.java
+++ b/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/SubmissionModelTests.java
@@ -17,9 +17,7 @@ package org.eclipse.pass.object.model;
 
 import static org.eclipse.pass.object.model.support.TestObjectCreator.createSubmission;
 import static org.eclipse.pass.object.model.support.TestObjectCreator.createUser;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -46,7 +44,7 @@ public class SubmissionModelTests {
         assertEquals(submission1.hashCode(), submission2.hashCode());
 
         submission1.setSubmissionStatus(SubmissionStatus.CANCELLED);
-        assertTrue(!submission1.equals(submission2));
+        assertNotEquals(submission1, submission2);
     }
 
     /**
@@ -68,7 +66,7 @@ public class SubmissionModelTests {
     @Test
     public void testSubmissionCopyConstructor()  {
         Submission submission = createSubmission(TestValues.SUBMISSION_ID_1);
-        List<User> preparersOrig = new ArrayList<>(Arrays.asList(createUser(TestValues.USER_ID_1)));
+        List<User> preparersOrig = List.of(createUser(TestValues.USER_ID_1));
         submission.setPreparers(preparersOrig);
         Submission submissionCopy = new Submission(submission);
         assertEquals(submission, submissionCopy);

--- a/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/UserModelTest.java
+++ b/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/UserModelTest.java
@@ -16,8 +16,7 @@
 package org.eclipse.pass.object.model;
 
 import static org.eclipse.pass.object.model.support.TestObjectCreator.createUser;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -43,7 +42,7 @@ public class UserModelTest {
         assertEquals(user1.hashCode(), user2.hashCode());
 
         user1.setUsername("different");
-        assertTrue(!user1.equals(user2));
+        assertNotEquals(user1, user2);
     }
 
     /**
@@ -52,7 +51,7 @@ public class UserModelTest {
     @Test
     public void testUserCopyConstructor()  {
         User user = createUser(TestValues.USER_ID_1);
-        List<UserRole> rolesOrig = new ArrayList<UserRole>(Arrays.asList(UserRole.ADMIN));
+        List<UserRole> rolesOrig = List.of(UserRole.ADMIN);
         user.setRoles(rolesOrig);
 
         User userCopy = new User(user);

--- a/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/UserModelTest.java
+++ b/pass-core-object-service/src/test/java/org/eclipse/pass/object/model/UserModelTest.java
@@ -16,7 +16,8 @@
 package org.eclipse.pass.object.model;
 
 import static org.eclipse.pass.object.model.support.TestObjectCreator.createUser;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/pass-core-policy-service/src/main/java/org/eclipse/pass/policy/service/PassPolicyServiceController.java
+++ b/pass-core-policy-service/src/main/java/org/eclipse/pass/policy/service/PassPolicyServiceController.java
@@ -33,7 +33,6 @@ import org.eclipse.pass.object.model.Policy;
 import org.eclipse.pass.object.model.Repository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -59,9 +58,6 @@ public class PassPolicyServiceController {
 
     private static final Logger LOG = LoggerFactory.getLogger(PassPolicyServiceController.class);
     private final PolicyService policyService;
-
-    @Autowired
-    private RefreshableElide refreshableElide;
 
     /**
      * PassPolicyServiceController Constructor

--- a/pass-core-policy-service/src/main/java/org/eclipse/pass/policy/service/PassPolicyServiceController.java
+++ b/pass-core-policy-service/src/main/java/org/eclipse/pass/policy/service/PassPolicyServiceController.java
@@ -46,6 +46,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 public class PassPolicyServiceController {
+    private static final Logger LOG = LoggerFactory.getLogger(PassPolicyServiceController.class);
 
     @Value("${pass.policy.institution}")
     private String institution;
@@ -56,7 +57,6 @@ public class PassPolicyServiceController {
     @Value("${pass.policy.institutional_repository_name}")
     private String institutionalRepositoryName;
 
-    private static final Logger LOG = LoggerFactory.getLogger(PassPolicyServiceController.class);
     private final PolicyService policyService;
 
     /**

--- a/pass-core-user-service/src/main/java/org/eclipse/pass/user/UserServiceController.java
+++ b/pass-core-user-service/src/main/java/org/eclipse/pass/user/UserServiceController.java
@@ -20,7 +20,6 @@ import org.eclipse.pass.usertoken.Token;
 import org.eclipse.pass.usertoken.TokenFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -36,15 +35,17 @@ public class UserServiceController {
 
     private final TokenFactory token_factory;
 
-    @Autowired
-    private RefreshableElide refreshableElide;
+    private final RefreshableElide refreshableElide;
 
     /**
      * Construct a UserServiceController.
      *
      * @param usertoken_key or null
+     * @param refreshableElide a refreshable elide instance
      */
-    public UserServiceController(@Value("${pass.usertoken.key:#{null}}") String usertoken_key) {
+    public UserServiceController(@Value("${pass.usertoken.key:#{null}}") String usertoken_key,
+                                 RefreshableElide refreshableElide) {
+        this.refreshableElide = refreshableElide;
         this.token_factory = usertoken_key == null || usertoken_key.isEmpty() ? null
                 : new TokenFactory(usertoken_key);
 

--- a/pass-core-user-service/src/main/java/org/eclipse/pass/user/UserServiceController.java
+++ b/pass-core-user-service/src/main/java/org/eclipse/pass/user/UserServiceController.java
@@ -34,7 +34,6 @@ public class UserServiceController {
     private static final Logger LOG = LoggerFactory.getLogger(UserServiceController.class);
 
     private final TokenFactory token_factory;
-
     private final RefreshableElide refreshableElide;
 
     /**


### PR DESCRIPTION
This PR is for the following issues:

https://github.com/eclipse-pass/main/issues/530
https://github.com/eclipse-pass/main/issues/470

Most changes are fairly straightforward code cleanup as requested in 530.  I used checkstyle, intellij code analysis, and PMD.  I didn't commit the PMD dependency, but let me know if we want to eventually add it.

There are a couple changes that I wanted to highlight:

- The addition of `logback-test.xml` to `pass-core-main/test/resources`.  This sets the default logging level for the console appender for WARN for all tests in this module.  This was added to fix 470.  If you want to see more logging from the tests for debugging purposes, this is the file to change.
- There are slightly more involved changes in the `pass-core-metadataschema-service` module.  I added spring annotations to the classes to clean up the IOC wiring up a bit.  I also changed the unit test mocking in this module to mock at a lower level in elide, this removed some code in the src classes that was there just for testing purposes.