### PR TITLE
Upgrade to Java 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,11 @@ jobs:
     steps:
       - name: "Checkout the repository"
         uses: actions/checkout@v2
-      - name: "Set up JDK 11"
-        uses: actions/setup-java@v1
+      - name: "Set up JDK 17"
+        uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 17
+          distribution: 'temurin'
       - name: "Cache Maven packages"
         uses: actions/cache@v2
         with:

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
           server-id: ossrh
           # User/pass refer to ENV VARs set below
           server-username: MAVEN_USERNAME # Sonatype user

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Setup Java & Maven
         uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'temurin'
           server-id: ossrh
           # User/pass refer to ENV VARs set below

--- a/.github/workflows/update-image.yml
+++ b/.github/workflows/update-image.yml
@@ -17,10 +17,10 @@ jobs:
       - name: Check out latest pass-core
         uses: actions/checkout@v3
 
-      - name: "Set up JDK 11"
+      - name: "Set up JDK 17"
         uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'temurin'
           cache: 'maven'
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This module is a Spring Boot application which provides the PASS REST API.
 
 # Building
 
-Java 11 and Maven 3.8 required.
+Java 17 and Maven 3.8 required.
 
 ```
 mvn clean install

--- a/pass-core-main/Dockerfile
+++ b/pass-core-main/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jre-slim
+FROM eclipse-temurin:17.0.7_7-jre
 
 WORKDIR /app
 

--- a/pass-core-main/docker-compose.yml
+++ b/pass-core-main/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - db:/var/lib/postgresql/data
       - ./init_postgres.sh:/docker-entrypoint-initdb.d/init_postgres.sh
   core:
-    image: ghcr.io/eclipse-pass/pass-core-main:0.3.0-SNAPSHOT
+    image: ghcr.io/eclipse-pass/pass-core-main:0.6.0-SNAPSHOT
     build:
       context: .
     env_file: .env

--- a/pass-core-policy-service/pom.xml
+++ b/pass-core-policy-service/pom.xml
@@ -10,8 +10,8 @@
   <artifactId>pass-core-policy-service</artifactId>
 
   <properties>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
 
   <dependencies>

--- a/pass-core-usertoken/src/main/java/org/eclipse/pass/usertoken/BadTokenException.java
+++ b/pass-core-usertoken/src/main/java/org/eclipse/pass/usertoken/BadTokenException.java
@@ -23,10 +23,19 @@ public class BadTokenException extends Exception {
 
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Constructor.
+     * @param message the error message
+     */
     public BadTokenException(String message) {
         super(message);
     }
 
+    /**
+     * Constructor taking the root throwable.
+     * @param message the error message
+     * @param e the root throwable
+     */
     public BadTokenException(String message, Throwable e) {
         super(message, e);
     }

--- a/pass-core-usertoken/src/main/java/org/eclipse/pass/usertoken/Key.java
+++ b/pass-core-usertoken/src/main/java/org/eclipse/pass/usertoken/Key.java
@@ -26,7 +26,6 @@ import org.apache.commons.codec.binary.Base32;
  * @author apb@jhu.edu
  */
 public class Key {
-    public static final String USER_TOKEN_KEY_PROPERTY = "pass.user.token.key";
 
     final byte[] bytes;
 

--- a/pass-core-usertoken/src/main/java/org/eclipse/pass/usertoken/KeyGenerator.java
+++ b/pass-core-usertoken/src/main/java/org/eclipse/pass/usertoken/KeyGenerator.java
@@ -26,6 +26,10 @@ public class KeyGenerator {
     private KeyGenerator() {
     }
 
+    /**
+     * Generates a key.
+     * @return the key
+     */
     protected static String generateKey() {
         return Key.generate().toString().replaceAll("=", "");
     }

--- a/pass-core-usertoken/src/main/java/org/eclipse/pass/usertoken/Token.java
+++ b/pass-core-usertoken/src/main/java/org/eclipse/pass/usertoken/Token.java
@@ -31,7 +31,14 @@ import java.util.Objects;
  * @author apb@jhu.edu
  */
 public class Token {
+    /**
+     * Param name for user token.
+     */
     public static final String USER_TOKEN_PARAM = "userToken";
+
+    /**
+     * Scheme name for pass resource.
+     */
     public static final String PASS_RESOURCE_SCHEME = "pass";
 
     private static final int REFERENCE_URI_INDEX = 0;
@@ -39,7 +46,7 @@ public class Token {
 
     private final URI resource;
     private final URI reference;
-    protected final Codec codec;
+    private final Codec codec;
 
     // Internal constructor
     Token(Codec codec, URI resource, URI reference) {
@@ -78,10 +85,18 @@ public class Token {
         return resource;
     }
 
+    /**
+     * Get the pass resource identifier.
+     * @return ID of pass resource
+     */
     public Long getPassResourceIdentifier() {
         return Long.parseLong(resource.getSchemeSpecificPart().split(":")[1]);
     }
 
+    /**
+     * Get the pass resource type.
+     * @return the type
+     */
     public String getPassResourceType() {
         return resource.getSchemeSpecificPart().split(":")[0];
     }

--- a/pass-core-usertoken/src/main/java/org/eclipse/pass/usertoken/TokenFactory.java
+++ b/pass-core-usertoken/src/main/java/org/eclipse/pass/usertoken/TokenFactory.java
@@ -26,7 +26,7 @@ import java.util.regex.Pattern;
  * @author apb@jhu.edu
  */
 public class TokenFactory {
-    protected final Codec codec;
+    private final Codec codec;
 
     private static final Pattern userTokenPattern = Pattern.compile(".*" + Token.USER_TOKEN_PARAM + "=([A-Z2-7]+).*");
 
@@ -74,7 +74,7 @@ public class TokenFactory {
      *
      * @param encoded String containing the encoded token.
      * @return The token.
-     * @throws BadTokenException
+     * @throws BadTokenException thrown if encoded token is invalid
      */
     public Token from(String encoded) throws BadTokenException {
         return new Token(codec, encoded);
@@ -85,7 +85,7 @@ public class TokenFactory {
      *
      * @param uri The URI to inspect
      * @return the Token, or null if none are present.
-     * @throws BadTokenException
+     * @throws BadTokenException thrown if token is invalid
      */
     public Token fromUri(URI uri) throws BadTokenException {
         final Matcher tokenMatcher = userTokenPattern.matcher(uri.getQuery());
@@ -101,7 +101,7 @@ public class TokenFactory {
      *
      * @param query The query to inspect
      * @return the Token, or null if none are present.
-     * @throws BadTokenException
+     * @throws BadTokenException thrown if token is invalid
      */
     public Token fromUri(String query) throws BadTokenException {
         final Matcher tokenMatcher = userTokenPattern.matcher(query);
@@ -125,10 +125,14 @@ public class TokenFactory {
     /**
      * Determing if a query string has a token in it.
      *
-     * @param query
+     * @param query the query to check for token
      * @return true if the query has a token parameter in it
      */
     public boolean hasToken(String query) {
         return userTokenPattern.matcher(query).matches();
+    }
+
+    Codec getCodec() {
+        return codec;
     }
 }

--- a/pass-core-usertoken/src/test/java/org/eclipse/pass/usertoken/TokenFactoryTest.java
+++ b/pass-core-usertoken/src/test/java/org/eclipse/pass/usertoken/TokenFactoryTest.java
@@ -44,7 +44,7 @@ public class TokenFactoryTest {
 
         final URI reference = randomUri();
 
-        final Token token = new Token(toTest.codec, resource, reference);
+        final Token token = new Token(toTest.getCodec(), resource, reference);
 
         final Token fromString = toTest.from(token.toString());
 
@@ -80,7 +80,7 @@ public class TokenFactoryTest {
 
         final String TEST = "test";
 
-        assertEquals(TEST, factory.codec.decrypt(withKnownKey.encrypt(TEST)));
+        assertEquals(TEST, factory.getCodec().decrypt(withKnownKey.encrypt(TEST)));
 
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
-          <source>11</source>
+          <source>17</source>
           <detectJavaApiLink>false</detectJavaApiLink>
           <tags>
           <tag>


### PR DESCRIPTION
Needed files have been updated to Java 17.

Changes are straight forward, but wanted to note that I set the FROM docker image a specific release of Java 17 in the `pass-core-main/Dockerfile` - `eclipse-temurin:17.0.7_7-jre`.  We could also set it to `eclipse-temurin:17-jre`, which would install the latest 17 GA release, but I figured we probably want to control this for releases.  Let me know otherwise.