### PR TITLE
FileService Access Control for Deleting Files

### DIFF
--- a/pass-core-file-service/pom.xml
+++ b/pass-core-file-service/pom.xml
@@ -91,6 +91,11 @@
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-core</artifactId>
+            <version>${spring.security.core.version}</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/pass-core-file-service/pom.xml
+++ b/pass-core-file-service/pom.xml
@@ -91,11 +91,5 @@
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-core</artifactId>
-            <version>${spring.security.core.version}</version>
-        </dependency>
     </dependencies>
-
 </project>

--- a/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/PassFileServiceController.java
+++ b/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/PassFileServiceController.java
@@ -154,12 +154,8 @@ public class PassFileServiceController {
     }
 
     private boolean canUserDeleteFile(String principalName, String fileId, HttpServletRequest request) {
-        if (request.isUserInRole(WebSecurityRole.BACKEND.getValue()) ||
-                fileStorageService.checkUserDeletePermissions(principalName, fileId)) {
-            return true;
-        } else {
-            return false;
-        }
+        return (request.isUserInRole(WebSecurityRole.BACKEND.getValue()) ||
+                fileStorageService.checkUserDeletePermissions(principalName, fileId));
     }
 
     private ResponseEntity deleteFile(String fileId) {

--- a/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/PassFileServiceController.java
+++ b/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/PassFileServiceController.java
@@ -156,7 +156,6 @@ public class PassFileServiceController {
     private boolean canUserDeleteFile(String principalName, String fileId, HttpServletRequest request) {
         if (request.isUserInRole(WebSecurityRole.BACKEND.getValue()) ||
                 fileStorageService.checkUserDeletePermissions(principalName, fileId)) {
-            fileStorageService.deleteFile(fileId);
             return true;
         } else {
             return false;

--- a/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/PassFileServiceController.java
+++ b/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/PassFileServiceController.java
@@ -19,13 +19,12 @@ package org.eclipse.pass.file.service;
 import java.io.IOException;
 import java.net.URI;
 import java.security.Principal;
-import java.util.Collection;
+import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.pass.file.service.storage.FileStorageService;
 import org.eclipse.pass.file.service.storage.StorageFile;
 import org.eclipse.pass.object.security.WebSecurityRole;
-import org.jsoup.internal.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.ByteArrayResource;
@@ -33,9 +32,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -44,8 +40,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import javax.servlet.http.HttpServletRequest;
 
 /**
  * PassFileServiceController is the controller class responsible for the File Service endpoints, which allows pass-core
@@ -73,6 +67,7 @@ public class PassFileServiceController {
      * deposited.
      *
      * @param file A multipart file that is uploaded from the client.
+     * @param principal The user that is uploading the file.
      * @return return a File object that has been uploaded.
      */
     @PostMapping("/file")
@@ -136,6 +131,8 @@ public class PassFileServiceController {
      *
      * @param uuid ID of the file to delete (required), is one part of the fileId
      * @param origFileName ID of the file to delete (required), is one part of the fileId
+     * @param principal the user making the request
+     * @param request the request
      * @return File
      */
     @DeleteMapping("/file/{uuid:.+}/{origFileName:.+}")
@@ -153,11 +150,11 @@ public class PassFileServiceController {
             return ResponseEntity.notFound().build();
         }
 
-        if(fileResource == null) {
+        if (fileResource == null) {
             return ResponseEntity.notFound().build();
         }
 
-        if(request.isUserInRole(WebSecurityRole.BACKEND.getValue()) ||
+        if (request.isUserInRole(WebSecurityRole.BACKEND.getValue()) ||
                 fileStorageService.checkUserDeletePermissions(principalName, fileId)) {
             fileStorageService.deleteFile(fileId);
             return ResponseEntity.ok().body("Deleted");

--- a/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/PassFileServiceController.java
+++ b/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/PassFileServiceController.java
@@ -106,11 +106,9 @@ public class PassFileServiceController {
      */
     @GetMapping("/file/{uuid:.+}/{origFileName:.+}")
     @ResponseBody
-    public ResponseEntity<?> getFileById(@PathVariable String uuid, @PathVariable String origFileName,
-                                         Principal principal) {
-        String principalName = principal.getName();
-        String fileId = principalName + "/" + uuid  + "/" + origFileName;
-        if (StringUtils.isEmpty(uuid) || StringUtils.isEmpty(origFileName) || StringUtils.isEmpty(principalName)) {
+    public ResponseEntity<?> getFileById(@PathVariable String uuid, @PathVariable String origFileName) {
+        String fileId = uuid  + "/" + origFileName;
+        if (StringUtils.isEmpty(uuid) || StringUtils.isEmpty(origFileName)) {
             LOG.error("File ID not provided to get a file.");
             return ResponseEntity.badRequest().body("File ID not provided to get a file.");
         }
@@ -145,7 +143,11 @@ public class PassFileServiceController {
                                             Principal principal, HttpServletRequest request) {
         String principalName = principal.getName();
         ByteArrayResource fileResource;
-        String fileId = principalName + "/" + uuid  + "/" + origFileName;
+        String fileId = uuid  + "/" + origFileName;
+
+        //If the file uuid and filename match, but the username does not then return 403.
+
+
         //check to see if the principal has a file with the UUID and filename. If not then return 403.
         try {
             fileResource = fileStorageService.getFile(fileId);

--- a/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/storage/FileStorageService.java
+++ b/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/storage/FileStorageService.java
@@ -31,6 +31,7 @@ import java.util.UUID;
 import edu.wisc.library.ocfl.api.OcflRepository;
 import edu.wisc.library.ocfl.api.exception.NotFoundException;
 import edu.wisc.library.ocfl.api.model.FileDetails;
+import edu.wisc.library.ocfl.api.model.ObjectDetails;
 import edu.wisc.library.ocfl.api.model.ObjectVersionId;
 import edu.wisc.library.ocfl.api.model.User;
 import edu.wisc.library.ocfl.api.model.VersionDetails;
@@ -383,7 +384,13 @@ public class FileStorageService {
     }
 
     public boolean checkUserDeletePermissions(String fileId, String userId) {
-        return true;
+        VersionInfo versionInfo = ocflRepository.describeVersion(ObjectVersionId.head(fileId)).getVersionInfo();
+        User user = versionInfo.getUser();
+        if (user.getName().equals(userId)) {
+            return true;
+        } else {
+            return false;
+        }
     }
 }
 

--- a/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/storage/FileStorageService.java
+++ b/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/storage/FileStorageService.java
@@ -376,5 +376,9 @@ public class FileStorageService {
             return "UNKNOWN_FILE_TYPE";
         }
     }
+
+    public boolean checkUserPermissionsForDelete(){
+        return true;
+    }
 }
 

--- a/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/storage/FileStorageService.java
+++ b/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/storage/FileStorageService.java
@@ -241,8 +241,7 @@ public class FileStorageService {
      *
      * @see StorageFile
      */
-    public StorageFile storeFile(MultipartFile mFile) throws IOException {
-        //TODO: refactor so that file is not stored with original file name, but with a UUID
+    public StorageFile storeFile(MultipartFile mFile, String userName) throws IOException {
         StorageFile storageFile = null;
         //NOTE: the work directory on the ocfl-java client should be located on the same mount as the OCFL storage root.
         try {
@@ -250,7 +249,7 @@ public class FileStorageService {
             String origFileNameExt = Jsoup.clean(mFile.getOriginalFilename(), Safelist.basic());
             String fileExt = FilenameUtils.getExtension(origFileNameExt);
             String fileUuid = UUID.randomUUID().toString();
-            String fileId = fileUuid + "/" + origFileNameExt;
+            String fileId = userName + "/" + fileUuid + "/" + origFileNameExt;
             String mimeType = URLConnection.guessContentTypeFromName(origFileNameExt);
             //changing the stored file name to UUID to prevent any issues with long file names
             //e.g. 260 char limit on the path in Windows. Original filename is preserved in the fileId.

--- a/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/storage/FileStorageService.java
+++ b/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/storage/FileStorageService.java
@@ -290,6 +290,7 @@ public class FileStorageService {
                     fileId,
                     fileUuid,
                     origFileNameExt,
+                    userName,
                     mimeType,
                     storageType.label,
                     mFile.getSize(),
@@ -392,9 +393,19 @@ public class FileStorageService {
      * @return Returns true if the user has permissions to delete the file, false if not.
      */
     public boolean checkUserDeletePermissions(String fileId, String userId) {
+        return userId.equals(getFileOwner(fileId));
+    }
+
+    /**
+     * Get the owner of the file from the fileID supplied. It will look at the most recent version of the file to
+     * obtain the owner.
+     *
+     * @param fileId The fileId of the file.
+     * @return The owner of the file.
+     */
+    public String getFileOwner(String fileId) {
         VersionInfo versionInfo = ocflRepository.describeVersion(ObjectVersionId.head(fileId)).getVersionInfo();
-        User user = versionInfo.getUser();
-        return user.getName().equals(userId);
+        return versionInfo.getUser().getName().toString();
     }
 }
 

--- a/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/storage/FileStorageService.java
+++ b/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/storage/FileStorageService.java
@@ -290,7 +290,6 @@ public class FileStorageService {
                     fileId,
                     fileUuid,
                     origFileNameExt,
-                    userName,
                     mimeType,
                     storageType.label,
                     mFile.getSize(),

--- a/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/storage/StorageFile.java
+++ b/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/storage/StorageFile.java
@@ -28,7 +28,6 @@ public class StorageFile {
     private String id;
     private String uuid;
     private String fileName;
-    private String fileOwner;
     private String mimeType;
     private String storageType;
     private Long size;
@@ -62,12 +61,11 @@ public class StorageFile {
      *
      * @see StorageServiceType
      */
-    public StorageFile(String id, String uuid, String fileName, String fileOwner, String mimeType, String storageType,
+    public StorageFile(String id, String uuid, String fileName, String mimeType, String storageType,
                        Long size, String extension) {
         this.id = id;
         this.uuid = uuid;
         this.fileName = fileName;
-        this.fileOwner = fileOwner;
         this.mimeType = mimeType;
         this.storageType = storageType;
         this.size = size;
@@ -112,14 +110,6 @@ public class StorageFile {
      **/
     public String getFileName() {
         return fileName;
-    }
-
-    /**
-     * Get fileOwner
-     * @return fileOwner of the StorageFile
-     **/
-    public String getFileOwner() {
-        return fileOwner;
     }
 
     /**
@@ -205,7 +195,6 @@ public class StorageFile {
         StorageFile storageFile = (StorageFile) o;
         return Objects.equals(this.id, storageFile.id) &&
                 Objects.equals(this.fileName, storageFile.fileName) &&
-                Objects.equals(this.fileOwner, storageFile.fileOwner) &&
                 Objects.equals(this.mimeType, storageFile.mimeType) &&
                 Objects.equals(this.storageType, storageFile.storageType) &&
                 Objects.equals(this.size, storageFile.size) &&
@@ -223,7 +212,6 @@ public class StorageFile {
         sb.append("class File {\n");
         sb.append("    id: ").append(toIndentedString(id)).append("\n");
         sb.append("    fileName: ").append(toIndentedString(fileName)).append("\n");
-        sb.append("    fileOwner: ").append(toIndentedString(fileOwner)).append("\n");
         sb.append("    mimeType: ").append(toIndentedString(mimeType)).append("\n");
         sb.append("    storageType: ").append(toIndentedString(storageType)).append("\n");
         sb.append("    size: ").append(toIndentedString(size)).append("\n");

--- a/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/storage/StorageFile.java
+++ b/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/storage/StorageFile.java
@@ -28,6 +28,7 @@ public class StorageFile {
     private String id;
     private String uuid;
     private String fileName;
+    private String fileOwner;
     private String mimeType;
     private String storageType;
     private Long size;
@@ -61,11 +62,12 @@ public class StorageFile {
      *
      * @see StorageServiceType
      */
-    public StorageFile(String id, String uuid, String fileName, String mimeType, String storageType, Long size,
-                       String extension) {
+    public StorageFile(String id, String uuid, String fileName, String fileOwner, String mimeType, String storageType,
+                       Long size, String extension) {
         this.id = id;
         this.uuid = uuid;
         this.fileName = fileName;
+        this.fileOwner = fileOwner;
         this.mimeType = mimeType;
         this.storageType = storageType;
         this.size = size;
@@ -110,6 +112,14 @@ public class StorageFile {
      **/
     public String getFileName() {
         return fileName;
+    }
+
+    /**
+     * Get fileOwner
+     * @return fileOwner of the StorageFile
+     **/
+    public String getFileOwner() {
+        return fileOwner;
     }
 
     /**
@@ -195,6 +205,7 @@ public class StorageFile {
         StorageFile storageFile = (StorageFile) o;
         return Objects.equals(this.id, storageFile.id) &&
                 Objects.equals(this.fileName, storageFile.fileName) &&
+                Objects.equals(this.fileOwner, storageFile.fileOwner) &&
                 Objects.equals(this.mimeType, storageFile.mimeType) &&
                 Objects.equals(this.storageType, storageFile.storageType) &&
                 Objects.equals(this.size, storageFile.size) &&
@@ -212,6 +223,7 @@ public class StorageFile {
         sb.append("class File {\n");
         sb.append("    id: ").append(toIndentedString(id)).append("\n");
         sb.append("    fileName: ").append(toIndentedString(fileName)).append("\n");
+        sb.append("    fileOwner: ").append(toIndentedString(fileOwner)).append("\n");
         sb.append("    mimeType: ").append(toIndentedString(mimeType)).append("\n");
         sb.append("    storageType: ").append(toIndentedString(storageType)).append("\n");
         sb.append("    size: ").append(toIndentedString(size)).append("\n");

--- a/pass-core-main/src/test/java/org/eclipse/pass/file/service/storage/FileStorageServiceS3Test.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/file/service/storage/FileStorageServiceS3Test.java
@@ -23,6 +23,7 @@ import org.springframework.util.FileSystemUtils;
 class FileStorageServiceS3Test {
     private final static String ROOT_DIR = System.getProperty("java.io.tmpdir") + "/pass-s3-test";
     private final static String USER_NAME = "USER1";
+    private final static String USER_NAME2 = "USER2";
 
     private FileStorageService fileStorageService;
     private final StorageProperties properties = new StorageProperties();
@@ -155,5 +156,33 @@ class FileStorageServiceS3Test {
         } catch (IOException e) {
             assertEquals("Exception during deleteShouldThrowExceptionFileNotExist", e.getMessage());
         }
+    }
+
+    //TODO: will be refactored in the next ticket #478
+    @Test
+    void userHasPermissionToDeleteFile() {
+        Boolean hasPermission = false;
+        try {
+            StorageFile storageFile = fileStorageService.storeFile(new MockMultipartFile("test", "test.txt",
+                    MediaType.TEXT_PLAIN_VALUE, "Test Pass-core".getBytes()), USER_NAME);
+            hasPermission = fileStorageService.checkUserDeletePermissions(storageFile.getId(), USER_NAME);
+        } catch (IOException e) {
+            assertEquals("Exception during userHasPermissionToDeleteFile", e.getMessage());
+        }
+        assertTrue(hasPermission);
+    }
+
+    //TODO: will be refactored in the next ticket #478
+    @Test
+    void userNoPermissionToDeleteFile() {
+        Boolean hasPermission = false;
+        try {
+            StorageFile storageFile = fileStorageService.storeFile(new MockMultipartFile("test", "test.txt",
+                    MediaType.TEXT_PLAIN_VALUE, "Test Pass-core".getBytes()), USER_NAME);
+            hasPermission = fileStorageService.checkUserDeletePermissions(storageFile.getId(), USER_NAME2);
+        } catch (IOException e) {
+            assertEquals("Exception during userHasPermissionToDeleteFile", e.getMessage());
+        }
+        assertFalse(hasPermission);
     }
 }

--- a/pass-core-main/src/test/java/org/eclipse/pass/file/service/storage/FileStorageServiceS3Test.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/file/service/storage/FileStorageServiceS3Test.java
@@ -33,7 +33,7 @@ class FileStorageServiceS3Test {
      * Setup the test environment. Uses custom endpoint for the in-memory S3 mock.
      */
     @BeforeEach
-    void setUp() {
+    void setUp() throws IOException {
         s3MockApi = new S3Mock.Builder().withPort(8001).withInMemoryBackend().build();
         s3MockApi.start();
         properties.setStorageType(StorageServiceType.S3);
@@ -47,11 +47,7 @@ class FileStorageServiceS3Test {
         System.setProperty("aws.accessKeyId", "A B C");
         System.setProperty("aws.secretAccessKey", "D E F");
 
-        try {
-            fileStorageService = new FileStorageService(storageConfiguration, "us-east-1");
-        } catch (IOException e) {
-            assertEquals("Exception during setup", e.getMessage());
-        }
+        fileStorageService = new FileStorageService(storageConfiguration, "us-east-1");
     }
 
     /**
@@ -67,29 +63,26 @@ class FileStorageServiceS3Test {
      * Test that the file is stored in the S3 mock.
      */
     @Test
-    void storeFileToS3ThatExists() {
-        try {
-            StorageFile storageFile = fileStorageService.storeFile(new MockMultipartFile("test", "test.txt",
-                    MediaType.TEXT_PLAIN_VALUE, "Test S3 Pass-core".getBytes()), USER_NAME);
-            assertFalse(fileStorageService.getResourceFileRelativePath(storageFile.getId()).isEmpty());
-        } catch (Exception e) {
-            assertEquals("An exception was thrown in storeFileThatExists.", e.getMessage());
-        }
+    void storeFileToS3ThatExists() throws IOException {
+        StorageFile storageFile = fileStorageService.storeFile(new MockMultipartFile("test", "test.txt",
+                MediaType.TEXT_PLAIN_VALUE, "Test S3 Pass-core".getBytes()), USER_NAME);
+        assertFalse(fileStorageService.getResourceFileRelativePath(storageFile.getId()).isEmpty());
+
+        //verify the object returned has the same owner
+        assertEquals(storageFile.getFileOwner(), USER_NAME);
+        //get the file from the S3 bucket and check that the owner is the same
+        assertEquals(fileStorageService.getFileOwner(storageFile.getId()), USER_NAME);
     }
 
     /**
      * Should get the file from the S3 bucket and return it.
      */
     @Test
-    void getFileFromS3ShouldReturnFile() {
-        try {
-            StorageFile storageFile = fileStorageService.storeFile(new MockMultipartFile("test", "test.txt",
-                    MediaType.TEXT_PLAIN_VALUE, "Test S3 Pass-core".getBytes()), USER_NAME);
-            ByteArrayResource file = fileStorageService.getFile(storageFile.getId());
-            assertTrue(file.contentLength() > 0);
-        } catch (IOException e) {
-            assertEquals("Exception during getFileShouldReturnFile", e.getMessage());
-        }
+    void getFileFromS3ShouldReturnFile() throws IOException {
+        StorageFile storageFile = fileStorageService.storeFile(new MockMultipartFile("test", "test.txt",
+                MediaType.TEXT_PLAIN_VALUE, "Test S3 Pass-core".getBytes()), USER_NAME);
+        ByteArrayResource file = fileStorageService.getFile(storageFile.getId());
+        assertTrue(file.contentLength() > 0);
     }
 
     /**
@@ -144,45 +137,33 @@ class FileStorageServiceS3Test {
      * Stores file, then deletes it. Should throw an exception because the file does not exist.
      */
     @Test
-    void deleteShouldThrowExceptionFileNotExist() {
-        try {
-            StorageFile storageFile = fileStorageService.storeFile(new MockMultipartFile("test", "test.txt",
-                    MediaType.TEXT_PLAIN_VALUE, "Test Pass-core".getBytes()), USER_NAME);
-            fileStorageService.deleteFile(storageFile.getId());
-            Exception exception = assertThrows(NotFoundException.class,
-                    () -> fileStorageService.getResourceFileRelativePath(storageFile.getId()));
-            String exceptionText = exception.getMessage();
-            assertTrue(exceptionText.matches("(.)+(was not found){1}(.)+"));
-        } catch (IOException e) {
-            assertEquals("Exception during deleteShouldThrowExceptionFileNotExist", e.getMessage());
-        }
+    void deleteShouldThrowExceptionFileNotExist() throws IOException {
+        StorageFile storageFile = fileStorageService.storeFile(new MockMultipartFile("test", "test.txt",
+                MediaType.TEXT_PLAIN_VALUE, "Test Pass-core".getBytes()), USER_NAME);
+        fileStorageService.deleteFile(storageFile.getId());
+        Exception exception = assertThrows(NotFoundException.class,
+                () -> fileStorageService.getResourceFileRelativePath(storageFile.getId()));
+        String exceptionText = exception.getMessage();
+        assertTrue(exceptionText.matches("(.)+(was not found){1}(.)+"));
     }
 
     //TODO: will be refactored in the next ticket #478
     @Test
-    void userHasPermissionToDeleteFile() {
+    void userHasPermissionToDeleteFile() throws IOException {
         Boolean hasPermission = false;
-        try {
-            StorageFile storageFile = fileStorageService.storeFile(new MockMultipartFile("test", "test.txt",
-                    MediaType.TEXT_PLAIN_VALUE, "Test Pass-core".getBytes()), USER_NAME);
-            hasPermission = fileStorageService.checkUserDeletePermissions(storageFile.getId(), USER_NAME);
-        } catch (IOException e) {
-            assertEquals("Exception during userHasPermissionToDeleteFile", e.getMessage());
-        }
+        StorageFile storageFile = fileStorageService.storeFile(new MockMultipartFile("test", "test.txt",
+                MediaType.TEXT_PLAIN_VALUE, "Test Pass-core".getBytes()), USER_NAME);
+        hasPermission = fileStorageService.checkUserDeletePermissions(storageFile.getId(), USER_NAME);
         assertTrue(hasPermission);
     }
 
     //TODO: will be refactored in the next ticket #478
     @Test
-    void userNoPermissionToDeleteFile() {
+    void userNoPermissionToDeleteFile() throws IOException {
         Boolean hasPermission = false;
-        try {
-            StorageFile storageFile = fileStorageService.storeFile(new MockMultipartFile("test", "test.txt",
-                    MediaType.TEXT_PLAIN_VALUE, "Test Pass-core".getBytes()), USER_NAME);
-            hasPermission = fileStorageService.checkUserDeletePermissions(storageFile.getId(), USER_NAME2);
-        } catch (IOException e) {
-            assertEquals("Exception during userHasPermissionToDeleteFile", e.getMessage());
-        }
+        StorageFile storageFile = fileStorageService.storeFile(new MockMultipartFile("test", "test.txt",
+                MediaType.TEXT_PLAIN_VALUE, "Test Pass-core".getBytes()), USER_NAME);
+        hasPermission = fileStorageService.checkUserDeletePermissions(storageFile.getId(), USER_NAME2);
         assertFalse(hasPermission);
     }
 }

--- a/pass-core-main/src/test/java/org/eclipse/pass/file/service/storage/FileStorageServiceS3Test.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/file/service/storage/FileStorageServiceS3Test.java
@@ -22,6 +22,7 @@ import org.springframework.util.FileSystemUtils;
 
 class FileStorageServiceS3Test {
     private final static String ROOT_DIR = System.getProperty("java.io.tmpdir") + "/pass-s3-test";
+    private final static String USER_NAME = "USER1";
 
     private FileStorageService fileStorageService;
     private final StorageProperties properties = new StorageProperties();
@@ -68,7 +69,7 @@ class FileStorageServiceS3Test {
     void storeFileToS3ThatExists() {
         try {
             StorageFile storageFile = fileStorageService.storeFile(new MockMultipartFile("test", "test.txt",
-                    MediaType.TEXT_PLAIN_VALUE, "Test S3 Pass-core".getBytes()));
+                    MediaType.TEXT_PLAIN_VALUE, "Test S3 Pass-core".getBytes()), USER_NAME);
             assertFalse(fileStorageService.getResourceFileRelativePath(storageFile.getId()).isEmpty());
         } catch (Exception e) {
             assertEquals("An exception was thrown in storeFileThatExists.", e.getMessage());
@@ -82,7 +83,7 @@ class FileStorageServiceS3Test {
     void getFileFromS3ShouldReturnFile() {
         try {
             StorageFile storageFile = fileStorageService.storeFile(new MockMultipartFile("test", "test.txt",
-                    MediaType.TEXT_PLAIN_VALUE, "Test S3 Pass-core".getBytes()));
+                    MediaType.TEXT_PLAIN_VALUE, "Test S3 Pass-core".getBytes()), USER_NAME);
             ByteArrayResource file = fileStorageService.getFile(storageFile.getId());
             assertTrue(file.contentLength() > 0);
         } catch (IOException e) {
@@ -129,7 +130,7 @@ class FileStorageServiceS3Test {
         allCharSets.forEach((k,v) -> {
             try {
                 StorageFile storageFile = fileStorageService.storeFile(new MockMultipartFile("test", v,
-                        MediaType.TEXT_PLAIN_VALUE, "Test Pass-core".getBytes()));
+                        MediaType.TEXT_PLAIN_VALUE, "Test Pass-core".getBytes()), USER_NAME);
                 assertFalse(fileStorageService.getResourceFileRelativePath(storageFile.getId()).isEmpty());
             } catch (IOException e) {
                 assertEquals("An exception was thrown in storeFileWithDifferentLangFilesNames. On charset=" + k,
@@ -145,7 +146,7 @@ class FileStorageServiceS3Test {
     void deleteShouldThrowExceptionFileNotExist() {
         try {
             StorageFile storageFile = fileStorageService.storeFile(new MockMultipartFile("test", "test.txt",
-                    MediaType.TEXT_PLAIN_VALUE, "Test Pass-core".getBytes()));
+                    MediaType.TEXT_PLAIN_VALUE, "Test Pass-core".getBytes()), USER_NAME);
             fileStorageService.deleteFile(storageFile.getId());
             Exception exception = assertThrows(NotFoundException.class,
                     () -> fileStorageService.getResourceFileRelativePath(storageFile.getId()));

--- a/pass-core-main/src/test/java/org/eclipse/pass/file/service/storage/FileStorageServiceS3Test.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/file/service/storage/FileStorageServiceS3Test.java
@@ -68,9 +68,7 @@ class FileStorageServiceS3Test {
                 MediaType.TEXT_PLAIN_VALUE, "Test S3 Pass-core".getBytes()), USER_NAME);
         assertFalse(fileStorageService.getResourceFileRelativePath(storageFile.getId()).isEmpty());
 
-        //verify the object returned has the same owner
-        assertEquals(storageFile.getFileOwner(), USER_NAME);
-        //get the file from the S3 bucket and check that the owner is the same
+        //check that the owner is the same
         assertEquals(fileStorageService.getFileOwner(storageFile.getId()), USER_NAME);
     }
 

--- a/pass-core-main/src/test/java/org/eclipse/pass/file/service/storage/FileStorageServiceTest.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/file/service/storage/FileStorageServiceTest.java
@@ -56,9 +56,7 @@ public class FileStorageServiceTest {
                 MediaType.TEXT_PLAIN_VALUE, "Test Pass-core".getBytes()), USER_NAME);
         assertFalse(fileStorageService.getResourceFileRelativePath(storageFile.getId()).isEmpty());
 
-        //verify the object returned has the same owner
-        assertEquals(storageFile.getFileOwner(), USER_NAME);
-        //get the file from the S3 bucket and check that the owner is the same
+        //check that the owner is the same
         assertEquals(fileStorageService.getFileOwner(storageFile.getId()), USER_NAME);
     }
 

--- a/pass-core-main/src/test/java/org/eclipse/pass/file/service/storage/FileStorageServiceTest.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/file/service/storage/FileStorageServiceTest.java
@@ -24,6 +24,7 @@ public class FileStorageServiceTest {
     private FileStorageService fileStorageService;
     private final StorageProperties properties = new StorageProperties();
     private final String rootDir = System.getProperty("java.io.tmpdir") + "/pass-file-system-test";
+    private final static String USER_NAME = "USER1";
 
     /**
      * Setup the FileStorageService for testing. Uses the system temp directory for the root directory.
@@ -60,7 +61,7 @@ public class FileStorageServiceTest {
     public void storeFileThatExists() {
         try {
             StorageFile storageFile = fileStorageService.storeFile(new MockMultipartFile("test", "test.txt",
-                    MediaType.TEXT_PLAIN_VALUE, "Test Pass-core".getBytes()));
+                    MediaType.TEXT_PLAIN_VALUE, "Test Pass-core".getBytes()), USER_NAME);
             assertFalse(fileStorageService.getResourceFileRelativePath(storageFile.getId()).isEmpty());
         } catch (Exception e) {
             assertEquals("An exception was thrown in storeFileThatExists.", e.getMessage());
@@ -74,7 +75,7 @@ public class FileStorageServiceTest {
     void getFileShouldReturnFile() {
         try {
             StorageFile storageFile = fileStorageService.storeFile(new MockMultipartFile("test", "test.txt",
-                    MediaType.TEXT_PLAIN_VALUE, "Test Pass-core".getBytes()));
+                    MediaType.TEXT_PLAIN_VALUE, "Test Pass-core".getBytes()), USER_NAME);
             ByteArrayResource file = fileStorageService.getFile(storageFile.getId());
             assertTrue(file.contentLength() > 0);
         } catch (IOException e) {
@@ -121,7 +122,7 @@ public class FileStorageServiceTest {
         allCharSets.forEach((k,v) -> {
             try {
                 StorageFile storageFile = fileStorageService.storeFile(new MockMultipartFile("test", v,
-                        MediaType.TEXT_PLAIN_VALUE, "Test Pass-core".getBytes()));
+                        MediaType.TEXT_PLAIN_VALUE, "Test Pass-core".getBytes()), USER_NAME);
                 assertFalse(fileStorageService.getResourceFileRelativePath(storageFile.getId()).isEmpty());
             } catch (IOException e) {
                 assertEquals("An exception was thrown in storeFileWithDifferentLangFilesNames. On charset=" + k,
@@ -137,7 +138,7 @@ public class FileStorageServiceTest {
     void deleteShouldThrowExceptionFileNotExist() {
         try {
             StorageFile storageFile = fileStorageService.storeFile(new MockMultipartFile("test", "test.txt",
-                    MediaType.TEXT_PLAIN_VALUE, "Test Pass-core".getBytes()));
+                    MediaType.TEXT_PLAIN_VALUE, "Test Pass-core".getBytes()), USER_NAME);
             fileStorageService.deleteFile(storageFile.getId());
             Exception exception = assertThrows(NotFoundException.class,
                     () -> {

--- a/pass-core-main/src/test/java/org/eclipse/pass/file/service/storage/FileStorageServiceTest.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/file/service/storage/FileStorageServiceTest.java
@@ -25,6 +25,7 @@ public class FileStorageServiceTest {
     private final StorageProperties properties = new StorageProperties();
     private final String rootDir = System.getProperty("java.io.tmpdir") + "/pass-file-system-test";
     private final static String USER_NAME = "USER1";
+    private final static String USER_NAME2 = "USER2";
 
     /**
      * Setup the FileStorageService for testing. Uses the system temp directory for the root directory.
@@ -151,4 +152,31 @@ public class FileStorageServiceTest {
         }
     }
 
+    //TODO: will be refactored in the next ticket #478
+    @Test
+    void userHasPermissionToDeleteFile() {
+        Boolean hasPermission = false;
+        try {
+            StorageFile storageFile = fileStorageService.storeFile(new MockMultipartFile("test", "test.txt",
+                    MediaType.TEXT_PLAIN_VALUE, "Test Pass-core".getBytes()), USER_NAME);
+            hasPermission = fileStorageService.checkUserDeletePermissions(storageFile.getId(), USER_NAME);
+        } catch (IOException e) {
+            assertEquals("Exception during userHasPermissionToDeleteFile", e.getMessage());
+        }
+        assertTrue(hasPermission);
+    }
+
+    //TODO: will be refactored in the next ticket #478
+    @Test
+    void userNoPermissionToDeleteFile() {
+        Boolean hasPermission = false;
+        try {
+            StorageFile storageFile = fileStorageService.storeFile(new MockMultipartFile("test", "test.txt",
+                    MediaType.TEXT_PLAIN_VALUE, "Test Pass-core".getBytes()), USER_NAME);
+            hasPermission = fileStorageService.checkUserDeletePermissions(storageFile.getId(), USER_NAME2);
+        } catch (IOException e) {
+            assertEquals("Exception during userHasPermissionToDeleteFile", e.getMessage());
+        }
+        assertFalse(hasPermission);
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,6 @@
     <commons.codec.version>1.13</commons.codec.version>
     <spring.boot.version>2.7.5</spring.boot.version>
     <amazon.sqs.version>1.0.4</amazon.sqs.version>
-    <spring.security.core.version>5.7.7</spring.security.core.version>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,7 @@
     <commons.codec.version>1.13</commons.codec.version>
     <spring.boot.version>2.7.5</spring.boot.version>
     <amazon.sqs.version>1.0.4</amazon.sqs.version>
+    <spring.security.core.version>5.7.7</spring.security.core.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
This PR will tighten the access control for deleting files in the `FileService`. Only the `BACKEND` user and the owner of the file can delete the file.

This PR is associated with this issue: https://github.com/eclipse-pass/main/issues/489

There are TODO comments on the File System and S3 integration tests for the check user permissions. This will be refactored in the next ticket to test at the controller level rather than service level. 

- Added method in the Service to check user delete permissions
- Modified the saving of a file to add the user name to the VersionDetails of the OCFL object
- Modified deleteFileById in the controller to check permissions and role of user. BACKEND user has rights to delete all files.

Testing:
`mvn verify`