### PR TITLE
Fix a couple bugs in file service

### DIFF
--- a/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/PassFileServiceController.java
+++ b/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/PassFileServiceController.java
@@ -143,7 +143,7 @@ public class PassFileServiceController {
 
         //Get the file, check that it exists, and then check if current user has permissions to delete
         try {
-            ByteArrayResource fileResource = fileStorageService.getFile(fileId);
+            fileStorageService.getFile(fileId);
         } catch (Exception e) {
             LOG.error("File Service: File not found: " + e);
             return ResponseEntity.notFound().build();
@@ -158,7 +158,7 @@ public class PassFileServiceController {
                 fileStorageService.checkUserDeletePermissions(principalName, fileId));
     }
 
-    private ResponseEntity deleteFile(String fileId) {
+    private ResponseEntity<?> deleteFile(String fileId) {
         fileStorageService.deleteFile(fileId);
         return ResponseEntity.ok().body("Deleted");
     }

--- a/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/storage/FileStorageService.java
+++ b/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/storage/FileStorageService.java
@@ -50,6 +50,7 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.stereotype.Service;
 import org.springframework.util.FileSystemUtils;
+import org.springframework.util.MimeTypeUtils;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
@@ -383,10 +384,16 @@ public class FileStorageService {
                     .orElseThrow(() -> new IOException("The content type could not be found for file ID: " + fileId));
             Path fileDetailPath = Paths.get(fileDetails.getPath());
             File file = fileDetailPath.toFile();
-            return Files.probeContentType(file.toPath());
+
+            String type = Files.probeContentType(file.toPath());
+            if (type == null) {
+                type = MimeTypeUtils.APPLICATION_OCTET_STREAM_VALUE;
+            }
+
+            return type;
         } catch (IOException e) {
-            LOG.error("File Service: Unable to determine the content type of the file with ID: " + fileId);
-            return "UNKNOWN_FILE_TYPE";
+            LOG.error("File Service: Unable to determine the content type of the file with ID: " + fileId, e);
+            return MimeTypeUtils.APPLICATION_OCTET_STREAM_VALUE;
         }
     }
 

--- a/pass-core-main/src/main/resources/application.yaml
+++ b/pass-core-main/src/main/resources/application.yaml
@@ -66,6 +66,10 @@ spring:
       name: ${PASS_CORE_BACKEND_USER:backend}
       password: ${PASS_CORE_BACKEND_PASSWORD:moo}
       roles: BACKEND
+  servlet:
+    multipart:
+      max-file-size: 100MB
+      max-request-size: 100MB
 
 server:
   port: 8080


### PR DESCRIPTION
Changes:
  * Handle the case of Files.probeContentType returning null. This prevented some files from working.
  * Handle the case of larger files by increasing the limit to 100 MB as specified by pass-ui. 