### PR TITLE
Fix updates to existing user on login

### DIFF
--- a/pass-core-main/src/main/java/org/eclipse/pass/main/security/ShibAuthenticationFilter.java
+++ b/pass-core-main/src/main/java/org/eclipse/pass/main/security/ShibAuthenticationFilter.java
@@ -16,6 +16,7 @@
 package org.eclipse.pass.main.security;
 
 import java.io.IOException;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import javax.servlet.FilterChain;
@@ -28,6 +29,7 @@ import org.eclipse.pass.object.PassClient;
 import org.eclipse.pass.object.PassClientResult;
 import org.eclipse.pass.object.PassClientSelector;
 import org.eclipse.pass.object.RSQL;
+import org.eclipse.pass.object.model.PassEntity;
 import org.eclipse.pass.object.model.User;
 import org.eclipse.pass.object.model.UserRole;
 import org.slf4j.Logger;
@@ -125,38 +127,43 @@ public class ShibAuthenticationFilter extends OncePerRequestFilter {
     private void update_pass_user(PassClient pass_client, User shib_user, User pass_user) throws IOException {
         boolean update = false;
 
-        if (!pass_user.getUsername().equals(shib_user.getUsername())) {
+        if (!Objects.equals(pass_user.getUsername(), shib_user.getUsername())) {
             pass_user.setUsername(shib_user.getUsername());
             update = true;
         }
 
-        if (!pass_user.getEmail().equals(shib_user.getEmail())) {
+        if (!Objects.equals(pass_user.getEmail(), shib_user.getEmail())) {
             pass_user.setEmail(shib_user.getEmail());
             update = true;
         }
 
-        if (!pass_user.getDisplayName().equals(shib_user.getDisplayName())) {
+        if (!Objects.equals(pass_user.getDisplayName(), shib_user.getDisplayName())) {
             pass_user.setDisplayName(shib_user.getDisplayName());
             update = true;
         }
 
-        if (!pass_user.getFirstName().equals(shib_user.getFirstName())) {
+        if (!Objects.equals(pass_user.getFirstName(), shib_user.getFirstName())) {
             pass_user.setFirstName(shib_user.getFirstName());
             update = true;
         }
 
-        if (!pass_user.getLastName().equals(shib_user.getLastName())) {
+        if (!Objects.equals(pass_user.getLastName(), shib_user.getLastName())) {
             pass_user.setLastName(shib_user.getLastName());
             update = true;
         }
 
-        if (!pass_user.getLocatorIds().equals(shib_user.getLocatorIds())) {
+        if (!PassEntity.listEquals(pass_user.getLocatorIds(), shib_user.getLocatorIds())) {
             pass_user.setLocatorIds(shib_user.getLocatorIds());
             update = true;
         }
 
-        if (!pass_user.getAffiliation().equals(shib_user.getAffiliation())) {
+        if (!Objects.equals(pass_user.getAffiliation(), shib_user.getAffiliation())) {
             pass_user.setAffiliation(shib_user.getAffiliation());
+            update = true;
+        }
+
+        if (!PassEntity.listEquals(pass_user.getRoles(), shib_user.getRoles())) {
+            pass_user.setRoles(shib_user.getRoles());
             update = true;
         }
 

--- a/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/PassEntity.java
+++ b/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/PassEntity.java
@@ -37,7 +37,7 @@ public abstract class PassEntity {
      * @param list2 List to compare
      * @return list equality
      */
-    protected static boolean listEquals(List<?> list1, List<?> list2) {
+    public static boolean listEquals(List<?> list1, List<?> list2) {
         if (list1 == list2) {
             return true;
         }

--- a/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/User.java
+++ b/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/User.java
@@ -280,7 +280,7 @@ public class User extends PassEntity {
                 && Objects.equals(email, other.email) && Objects.equals(firstName, other.firstName)
                 && Objects.equals(lastName, other.lastName) && listEquals(locatorIds, other.locatorIds)
                 && Objects.equals(middleName, other.middleName) && Objects.equals(orcidId, other.orcidId)
-                && Objects.equals(roles, other.roles) && Objects.equals(username, other.username);
+                && listEquals(roles, other.roles) && Objects.equals(username, other.username);
     }
 
     @Override


### PR DESCRIPTION
The check against information provided by the shib request against an existing user object made too many assumptions. This pr fixes the equality checks and add a test.