### PR TITLE
Create indexes on User locator ids and Journal issns

### DIFF
--- a/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/Journal.java
+++ b/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/Journal.java
@@ -18,10 +18,12 @@ package org.eclipse.pass.object.model;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import javax.persistence.CollectionTable;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.Index;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
@@ -35,9 +37,9 @@ import com.yahoo.elide.annotation.Include;
 
 @Include
 @Entity
-@Table(name = "pass_journal")
+@Table(name = "pass_journal", indexes = {
+    @Index(name = "pass_journal_name_ix", columnList = "journalname")})
 public class Journal extends PassEntity {
-
     /**
      * Name of journal
      */
@@ -47,6 +49,9 @@ public class Journal extends PassEntity {
      * Array of ISSN(s) for Journal
      */
     @ElementCollection(targetClass = String.class)
+    @CollectionTable(name = "pass_journal_issns", indexes = {
+        @Index(name = "pass_journal_issns_id_ix", columnList = "journal_id"),
+        @Index(name = "pass_journal_issns_issn_ix", columnList = "issns")})
     private List<String> issns = new ArrayList<>();
 
     /**

--- a/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/User.java
+++ b/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/User.java
@@ -20,9 +20,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import javax.persistence.CollectionTable;
 import javax.persistence.Convert;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
+import javax.persistence.Index;
 import javax.persistence.Table;
 
 import com.yahoo.elide.annotation.Include;
@@ -85,6 +87,9 @@ public class User extends PassEntity {
      * "johnshopkins.edu:jhed:bostaur1"]}
      */
     @ElementCollection(targetClass = String.class)
+    @CollectionTable(name = "pass_user_locators", indexes = {
+        @Index(name = "pass_user_locators_id_ix", columnList = "user_id"),
+        @Index(name = "pass_user_locators_locator_ix", columnList = "locatorids")})
     private List<String> locatorIds = new ArrayList<String>();
 
     /**


### PR DESCRIPTION
User locator ids and Journal issns are both lists of string that have to be indexed appropriately in order for searches on them to be fast. This pr adds indexes on the tables which handle those properties.