### PR TITLE
Add indexes for common queries

### DIFF
--- a/pass-core-main/src/main/resources/db/changelog/changelog.yaml
+++ b/pass-core-main/src/main/resources/db/changelog/changelog.yaml
@@ -36,3 +36,26 @@ databaseChangeLog:
             columns:
             - column:
                 name: externalids
+  -  changeSet:
+       id:  4
+       author:  mark-patton
+       changes:
+         - sqlFile:
+             encoding: utf-8
+             path: /db/changelog/schema/indices.sql
+             splitStatements: true
+             stripComments: true
+  -  changeSet:
+       id:  5
+       author:  mark-patton
+       preConditions:
+         - dbms:
+             type: postgresql
+         - onFail: MARK_RAN
+       changes:
+         - sqlFile:
+             encoding: utf-8
+             path: /db/changelog/schema/postgres-pattern-indices.sql
+             splitStatements: true
+             stripComments: true
+

--- a/pass-core-main/src/main/resources/db/changelog/changelog.yaml
+++ b/pass-core-main/src/main/resources/db/changelog/changelog.yaml
@@ -48,10 +48,7 @@ databaseChangeLog:
   -  changeSet:
        id:  5
        author:  mark-patton
-       preConditions:
-         - dbms:
-             type: postgresql
-         - onFail: MARK_RAN
+       dbms: postgresql
        changes:
          - sqlFile:
              encoding: utf-8

--- a/pass-core-main/src/main/resources/db/changelog/schema/indices.sql
+++ b/pass-core-main/src/main/resources/db/changelog/schema/indices.sql
@@ -1,0 +1,28 @@
+-- Add indices for columns that are searched including most foreign keys
+
+CREATE INDEX pass_grant_pi_ix ON public.pass_grant (pi_id);
+
+CREATE INDEX pass_grant_copis_grant_ix ON public.pass_grant_copis (grant_id);
+CREATE INDEX pass_grant_copis_copi_ix ON public.pass_grant_copis (copis_id);
+
+CREATE INDEX pass_deposit_submission_ix ON public.pass_deposit (submission_id);
+CREATE INDEX pass_deposit_status_ix ON public.pass_deposit (depositstatus);
+
+CREATE INDEX pass_file_submission_ix ON public.pass_file (submission_id);
+
+CREATE INDEX pass_submission_status_ix ON public.pass_submission (submissionstatus);
+CREATE INDEX pass_submission_submitter_ix ON public.pass_submission (submitter_id);
+CREATE INDEX pass_submission_publication_ix ON public.pass_submission (publication_id);
+
+CREATE INDEX pass_submission_preparers_submission_ix ON public.pass_submission_preparers (submission_id);
+CREATE INDEX pass_submission_preparers_preparer_ix ON public.pass_submission_preparers (preparers_id);
+
+CREATE INDEX pass_submission_effectivepolicies_submission_ix ON public.pass_submission_effectivepolicies (submission_id);
+
+CREATE INDEX pass_submission_event_submission_ix ON public.pass_submission_event (submission_id);
+
+CREATE INDEX pass_policy_repositories_policy_ix ON public.pass_policy_repositories (policy_id);
+
+CREATE INDEX pass_repository_copy_publication_ix ON public.pass_repository_copy (publication_id);
+
+CREATE INDEX pass_repository_copy_externalids_rc_ix ON public.pass_repository_copy_external_ids (repositorycopy_id);

--- a/pass-core-main/src/main/resources/db/changelog/schema/postgres-pattern-indices.sql
+++ b/pass-core-main/src/main/resources/db/changelog/schema/postgres-pattern-indices.sql
@@ -1,0 +1,11 @@
+-- Make LIKE operations faster for Journal names and Grant award numbers
+-- For journal names RSQL ini is used which results in lower() in the SQL which the index must match
+
+-- One approach is to use varchar_pattern_ops
+-- CREATE INDEX pass_grant_awardnumber_ix ON public.pass_grant (awardnumber varchar_pattern_ops);
+-- CREATE INDEX pass_journal_name_ix ON public.pass_journal (lower(journalname) varchar_pattern_ops);
+
+-- Trigrams seem faster
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+CREATE INDEX pass_journal_name_ix ON public.pass_journal USING GIN(lower(journalname) gin_trgm_ops);
+CREATE INDEX pass_grant_awardnumber_ix ON public.pass_grant USING GIN(awardnumber gin_trgm_ops);


### PR DESCRIPTION
Indexes added for most common queries.
For award number and journal name there are postgres specific indexes.

In order to test, try running pass-core by itself using the builtin db and also with postgres.