### PR TITLE
[pass-core] Submission and Deposit entity optimistic locking

### DIFF
--- a/pass-core-main/src/main/java/org/eclipse/pass/main/JmsConfiguration.java
+++ b/pass-core-main/src/main/java/org/eclipse/pass/main/JmsConfiguration.java
@@ -247,7 +247,8 @@ public class JmsConfiguration {
 
     private Long getRequestVersion(RequestScope scope) {
         Object requestVersion = scope.getJsonApiDocument().getData().getSingleValue().getAttributes().get("version");
-        return Objects.isNull(requestVersion) ? null : Long.parseLong(requestVersion.toString());
+        // The string -> double -> long conversion is needed because json could send number as float
+        return Objects.isNull(requestVersion) ? null : Double.valueOf(requestVersion.toString()).longValue();
     }
 
     private void validateEntityVersions(Long repoVersion, Long requestVersion, PassEntity passEntity) {

--- a/pass-core-main/src/main/java/org/eclipse/pass/main/JmsConfiguration.java
+++ b/pass-core-main/src/main/java/org/eclipse/pass/main/JmsConfiguration.java
@@ -187,7 +187,9 @@ public class JmsConfiguration {
      * This Bean override for RefreshableElide is needed because of the `withUpdate200Status` setting.
      * If Elide adds this to the config props, then it can be set application.yml, but until then,
      * this is the only way of changing this setting.
-     * The other setting were pulled from the ElideAutoConfiguration.getRefreshableElide method.
+     * <p>
+     * The other settings were copied from the ElideAutoConfiguration.getRefreshableElide method.
+     *
      * @param dictionary the elide dictionary
      * @param dataStore the elide datastore
      * @param headerProcessor the elide header processor

--- a/pass-core-main/src/main/java/org/eclipse/pass/main/JmsConfiguration.java
+++ b/pass-core-main/src/main/java/org/eclipse/pass/main/JmsConfiguration.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.eclipse.pass.main;
 
 import java.net.URI;

--- a/pass-core-main/src/main/java/org/eclipse/pass/main/PassErrorMapper.java
+++ b/pass-core-main/src/main/java/org/eclipse/pass/main/PassErrorMapper.java
@@ -24,6 +24,9 @@ import org.jetbrains.annotations.Nullable;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
+/**
+ * @author Russ Poetker (rpoetke1@jh.edu)
+ */
 @Component
 public class PassErrorMapper implements ErrorMapper {
     @Nullable

--- a/pass-core-main/src/main/java/org/eclipse/pass/main/PassErrorMapper.java
+++ b/pass-core-main/src/main/java/org/eclipse/pass/main/PassErrorMapper.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.pass.main;
+
+import javax.persistence.OptimisticLockException;
+
+import com.yahoo.elide.core.exceptions.CustomErrorException;
+import com.yahoo.elide.core.exceptions.ErrorMapper;
+import com.yahoo.elide.core.exceptions.ErrorObjects;
+import org.jetbrains.annotations.Nullable;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PassErrorMapper implements ErrorMapper {
+    @Nullable
+    @Override
+    public CustomErrorException map(Exception e) {
+        if (e instanceof OptimisticLockException) {
+            ErrorObjects errors = ErrorObjects.builder().addError().withDetail(e.getMessage()).build();
+            return new CustomErrorException(HttpStatus.CONFLICT.value(), e.getMessage(), errors);
+        }
+        return null;
+    }
+}

--- a/pass-core-main/src/main/java/org/eclipse/pass/main/repository/DepositRepository.java
+++ b/pass-core-main/src/main/java/org/eclipse/pass/main/repository/DepositRepository.java
@@ -1,0 +1,11 @@
+package org.eclipse.pass.main.repository;
+
+import org.eclipse.pass.object.model.Deposit;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+
+public interface DepositRepository extends CrudRepository<Deposit, String> {
+
+    @Query("select d.version from Deposit d where d.id = ?1")
+    Long findDepositVersionById(Long depositId);
+}

--- a/pass-core-main/src/main/java/org/eclipse/pass/main/repository/DepositRepository.java
+++ b/pass-core-main/src/main/java/org/eclipse/pass/main/repository/DepositRepository.java
@@ -19,8 +19,16 @@ import org.eclipse.pass.object.model.Deposit;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 
+/**
+ * @author Russ Poetker (rpoetke1@jh.edu)
+ */
 public interface DepositRepository extends CrudRepository<Deposit, String> {
 
+    /**
+     * Returns deposit version from datastore.
+     * @param depositId the id of the deposit
+     * @return the deposit version
+     */
     @Query("select d.version from Deposit d where d.id = ?1")
     Long findDepositVersionById(Long depositId);
 }

--- a/pass-core-main/src/main/java/org/eclipse/pass/main/repository/DepositRepository.java
+++ b/pass-core-main/src/main/java/org/eclipse/pass/main/repository/DepositRepository.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.eclipse.pass.main.repository;
 
 import org.eclipse.pass.object.model.Deposit;

--- a/pass-core-main/src/main/java/org/eclipse/pass/main/repository/SubmissionRepository.java
+++ b/pass-core-main/src/main/java/org/eclipse/pass/main/repository/SubmissionRepository.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.eclipse.pass.main.repository;
 
 import org.eclipse.pass.object.model.Submission;

--- a/pass-core-main/src/main/java/org/eclipse/pass/main/repository/SubmissionRepository.java
+++ b/pass-core-main/src/main/java/org/eclipse/pass/main/repository/SubmissionRepository.java
@@ -19,8 +19,16 @@ import org.eclipse.pass.object.model.Submission;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 
+/**
+ * @author Russ Poetker (rpoetke1@jh.edu)
+ */
 public interface SubmissionRepository extends CrudRepository<Submission, String> {
 
+    /**
+     * Returns submission version from datastore.
+     * @param submissionId the id of the submission
+     * @return the submission version
+     */
     @Query("select s.version from Submission s where s.id = ?1")
     Long findSubmissionVersionById(Long submissionId);
 }

--- a/pass-core-main/src/main/java/org/eclipse/pass/main/repository/SubmissionRepository.java
+++ b/pass-core-main/src/main/java/org/eclipse/pass/main/repository/SubmissionRepository.java
@@ -1,0 +1,11 @@
+package org.eclipse.pass.main.repository;
+
+import org.eclipse.pass.object.model.Submission;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+
+public interface SubmissionRepository extends CrudRepository<Submission, String> {
+
+    @Query("select s.version from Submission s where s.id = ?1")
+    Long findSubmissionVersionById(Long submissionId);
+}

--- a/pass-core-main/src/main/resources/db/changelog/changelog.yaml
+++ b/pass-core-main/src/main/resources/db/changelog/changelog.yaml
@@ -82,3 +82,20 @@ databaseChangeLog:
              path: /db/changelog/schema/remove-contrib-pub.sql
              splitStatements: true
              stripComments: true
+  - changeSet:
+      id: 9
+      author: russ-poetker
+      changes:
+        - addColumn:
+            tableName: pass_submission
+            columns:
+              - column:
+                  name: version
+                  type: bigint
+        - addColumn:
+            tableName: pass_deposit
+            columns:
+              - column:
+                  name: version
+                  type: bigint
+

--- a/pass-core-main/src/main/resources/db/changelog/changelog.yaml
+++ b/pass-core-main/src/main/resources/db/changelog/changelog.yaml
@@ -98,4 +98,9 @@ databaseChangeLog:
               - column:
                   name: version
                   type: bigint
+        - sqlFile:
+            encoding: utf-8
+            path: /db/changelog/data/version-migration.sql
+            splitStatements: true
+            stripComments: true
 

--- a/pass-core-main/src/main/resources/db/changelog/data/version-migration.sql
+++ b/pass-core-main/src/main/resources/db/changelog/data/version-migration.sql
@@ -1,0 +1,2 @@
+update pass_submission set version = 0;
+update pass_deposit set version = 0;

--- a/pass-core-main/src/test/java/org/eclipse/pass/main/security/AccessControlTest.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/main/security/AccessControlTest.java
@@ -268,7 +268,7 @@ public class AccessControlTest extends ShibIntegrationTest {
 
             Response response = client.newCall(request).execute();
 
-            check(response, 204);
+            check(response, 200);
         }
 
         {
@@ -314,7 +314,7 @@ public class AccessControlTest extends ShibIntegrationTest {
 
             Response response = client.newCall(request).execute();
 
-            check(response, 204);
+            check(response, 200);
         }
 
         {
@@ -375,7 +375,7 @@ public class AccessControlTest extends ShibIntegrationTest {
 
             Response response = client.newCall(request).execute();
 
-            check(response, 204);
+            check(response, 200);
         }
 
         {
@@ -571,7 +571,7 @@ public class AccessControlTest extends ShibIntegrationTest {
 
             Response response = client.newCall(request).execute();
 
-            check(response, 204);
+            check(response, 200);
         }
 
         // Delete the grant

--- a/pass-core-main/src/test/java/org/eclipse/pass/object/ElideDataStorePassClientTest.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/object/ElideDataStorePassClientTest.java
@@ -43,6 +43,7 @@ public class ElideDataStorePassClientTest extends PassClientTest {
 
     @Test
     public void testUpdateSubmission_OptimisticLocking() throws IOException {
+        // GIVEN
         Submission submission = new Submission();
         submission.setAggregatedDepositStatus(AggregatedDepositStatus.NOT_STARTED);
         submission.setSubmissionStatus(SubmissionStatus.DRAFT);
@@ -56,6 +57,7 @@ public class ElideDataStorePassClientTest extends PassClientTest {
         updateSub1.setSubmissionStatus(SubmissionStatus.SUBMITTED);
         client.updateObject(updateSub1);
 
+        // WHEN/THEN
         TransactionException transactionException = assertThrows(TransactionException.class, () -> {
             updateSub2.setSource(null);
             updateSub2.setSubmissionStatus(SubmissionStatus.CHANGES_REQUESTED);
@@ -70,6 +72,7 @@ public class ElideDataStorePassClientTest extends PassClientTest {
 
     @Test
     public void testUpdateDeposit_OptimisticLocking() throws IOException {
+        // GIVEN
         Deposit deposit = new Deposit();
         deposit.setDepositStatus(DepositStatus.SUBMITTED);
         client.createObject(deposit);
@@ -80,6 +83,7 @@ public class ElideDataStorePassClientTest extends PassClientTest {
         updateDep1.setDepositStatus(DepositStatus.FAILED);
         client.updateObject(updateDep1);
 
+        // WHEN/THEN
         TransactionException transactionException = assertThrows(TransactionException.class, () -> {
             updateDep2.setDepositStatus(DepositStatus.ACCEPTED);
             client.updateObject(updateDep2);

--- a/pass-core-main/src/test/java/org/eclipse/pass/object/ElideDataStorePassClientTest.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/object/ElideDataStorePassClientTest.java
@@ -15,7 +15,21 @@
  */
 package org.eclipse.pass.object;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import javax.persistence.OptimisticLockException;
+
 import com.yahoo.elide.RefreshableElide;
+import com.yahoo.elide.core.exceptions.TransactionException;
+import org.eclipse.pass.object.model.AggregatedDepositStatus;
+import org.eclipse.pass.object.model.Deposit;
+import org.eclipse.pass.object.model.DepositStatus;
+import org.eclipse.pass.object.model.Source;
+import org.eclipse.pass.object.model.Submission;
+import org.eclipse.pass.object.model.SubmissionStatus;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public class ElideDataStorePassClientTest extends PassClientTest {
@@ -25,5 +39,55 @@ public class ElideDataStorePassClientTest extends PassClientTest {
     @Override
     protected PassClient getNewClient() {
         return new ElideDataStorePassClient(refreshableElide);
+    }
+
+    @Test
+    public void testUpdateSubmission_OptimisticLocking() throws IOException {
+        Submission submission = new Submission();
+        submission.setAggregatedDepositStatus(AggregatedDepositStatus.NOT_STARTED);
+        submission.setSubmissionStatus(SubmissionStatus.DRAFT);
+        submission.setSubmitterName("Bessie");
+        client.createObject(submission);
+
+        Submission updateSub1 = client.getObject(submission.getClass(), submission.getId());
+        Submission updateSub2 = client.getObject(submission.getClass(), submission.getId());
+
+        updateSub1.setSource(Source.OTHER);
+        updateSub1.setSubmissionStatus(SubmissionStatus.SUBMITTED);
+        client.updateObject(updateSub1);
+
+        TransactionException transactionException = assertThrows(TransactionException.class, () -> {
+            updateSub2.setSource(null);
+            updateSub2.setSubmissionStatus(SubmissionStatus.CHANGES_REQUESTED);
+            client.updateObject(updateSub2);
+        });
+
+        OptimisticLockException optimisticLockException = (OptimisticLockException) transactionException.getCause();
+        assertTrue(optimisticLockException.getMessage().startsWith(
+            "Row was updated or deleted by another transaction (or unsaved-value mapping was incorrect) : " +
+                "[org.eclipse.pass.object.model.Submission#"));
+    }
+
+    @Test
+    public void testUpdateDeposit_OptimisticLocking() throws IOException {
+        Deposit deposit = new Deposit();
+        deposit.setDepositStatus(DepositStatus.SUBMITTED);
+        client.createObject(deposit);
+
+        Deposit updateDep1 = client.getObject(deposit.getClass(), deposit.getId());
+        Deposit updateDep2 = client.getObject(deposit.getClass(), deposit.getId());
+
+        updateDep1.setDepositStatus(DepositStatus.FAILED);
+        client.updateObject(updateDep1);
+
+        TransactionException transactionException = assertThrows(TransactionException.class, () -> {
+            updateDep2.setDepositStatus(DepositStatus.ACCEPTED);
+            client.updateObject(updateDep2);
+        });
+
+        OptimisticLockException optimisticLockException = (OptimisticLockException) transactionException.getCause();
+        assertTrue(optimisticLockException.getMessage().startsWith(
+            "Row was updated or deleted by another transaction (or unsaved-value mapping was incorrect) : " +
+                "[org.eclipse.pass.object.model.Deposit#"));
     }
 }

--- a/pass-core-main/src/test/java/org/eclipse/pass/object/ElidePassClientTest.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/object/ElidePassClientTest.java
@@ -15,6 +15,7 @@
  */
 package org.eclipse.pass.object;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -38,6 +39,37 @@ public class ElidePassClientTest extends PassClientTest {
     @Override
     protected PassClient getNewClient() {
         return new ElidePassClient(refreshableElide);
+    }
+
+    @Test
+    public void testUpdateObject_CheckVersionUpdate() throws IOException {
+        Submission submission = new Submission();
+
+        submission.setAggregatedDepositStatus(AggregatedDepositStatus.NOT_STARTED);
+        submission.setSubmissionStatus(SubmissionStatus.DRAFT);
+        submission.setSubmitterName("Bessie");
+
+        client.createObject(submission);
+        assertEquals(0, submission.getVersion());
+
+        submission.setSource(Source.OTHER);
+        submission.setSubmissionStatus(SubmissionStatus.SUBMITTED);
+
+        client.updateObject(submission);
+        assertEquals(1, submission.getVersion());
+
+        Submission test = client.getObject(submission.getClass(), submission.getId());
+
+        assertEquals(submission.getId(), test.getId());
+        assertEquals(submission.getAggregatedDepositStatus(), test.getAggregatedDepositStatus());
+        assertEquals(submission.getSubmitterName(), test.getSubmitterName());
+        assertEquals(submission.getSource(), test.getSource());
+        assertEquals(submission.getSubmissionStatus(), test.getSubmissionStatus());
+        assertEquals(submission.getMetadata(), test.getMetadata());
+        assertEquals(1, test.getVersion());
+
+        // The lazy loading of objects from relationships does not play nicely with equality tests
+        // assertEquals(submission, test);
     }
 
     @Test

--- a/pass-core-main/src/test/java/org/eclipse/pass/object/ElidePassClientTest.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/object/ElidePassClientTest.java
@@ -43,19 +43,24 @@ public class ElidePassClientTest extends PassClientTest {
 
     @Test
     public void testUpdateObject_CheckVersionUpdate() throws IOException {
+        // GIVEN
         Submission submission = new Submission();
-
         submission.setAggregatedDepositStatus(AggregatedDepositStatus.NOT_STARTED);
         submission.setSubmissionStatus(SubmissionStatus.DRAFT);
         submission.setSubmitterName("Bessie");
 
+        // WHEN
         client.createObject(submission);
+
+        // THEN
         assertEquals(0, submission.getVersion());
 
+        // WHEN
         submission.setSource(Source.OTHER);
         submission.setSubmissionStatus(SubmissionStatus.SUBMITTED);
-
         client.updateObject(submission);
+
+        // THEN
         assertEquals(1, submission.getVersion());
 
         Submission test = client.getObject(submission.getClass(), submission.getId());
@@ -74,6 +79,7 @@ public class ElidePassClientTest extends PassClientTest {
 
     @Test
     public void testUpdateSubmission_OptimisticLocking() throws IOException {
+        // GIVEN
         Submission submission = new Submission();
         submission.setAggregatedDepositStatus(AggregatedDepositStatus.NOT_STARTED);
         submission.setSubmissionStatus(SubmissionStatus.DRAFT);
@@ -89,6 +95,7 @@ public class ElidePassClientTest extends PassClientTest {
         updateSub1.setSubmissionStatus(SubmissionStatus.SUBMITTED);
         client.updateObject(updateSub1);
 
+        // WHEN/THEN
         IOException ioException = assertThrows(IOException.class, () -> {
             updateSub2.setSource(null);
             updateSub2.setSubmissionStatus(SubmissionStatus.CHANGES_REQUESTED);
@@ -102,6 +109,7 @@ public class ElidePassClientTest extends PassClientTest {
 
     @Test
     public void testUpdateSubmission_OptimisticLocking_NullVersion() throws IOException {
+        // GIVEN
         Submission submission = new Submission();
         submission.setAggregatedDepositStatus(AggregatedDepositStatus.NOT_STARTED);
         submission.setSubmissionStatus(SubmissionStatus.DRAFT);
@@ -116,6 +124,7 @@ public class ElidePassClientTest extends PassClientTest {
 
         client.updateObject(updateSub1);
 
+        // WHEN/THEN
         IOException ioException = assertThrows(IOException.class, () -> {
             updateSub2.setSource(null);
             updateSub2.setSubmissionStatus(SubmissionStatus.CHANGES_REQUESTED);
@@ -130,6 +139,7 @@ public class ElidePassClientTest extends PassClientTest {
 
     @Test
     public void testUpdateDeposit_OptimisticLocking() throws IOException {
+        // GIVEN
         Deposit deposit = new Deposit();
         deposit.setDepositStatus(DepositStatus.SUBMITTED);
         client.createObject(deposit);
@@ -142,6 +152,7 @@ public class ElidePassClientTest extends PassClientTest {
         updateDep1.setDepositStatus(DepositStatus.FAILED);
         client.updateObject(updateDep1);
 
+        // WHEN/THEN
         IOException ioException = assertThrows(IOException.class, () -> {
             updateDep2.setDepositStatus(DepositStatus.ACCEPTED);
             client.updateObject(updateDep2);
@@ -154,6 +165,7 @@ public class ElidePassClientTest extends PassClientTest {
 
     @Test
     public void testUpdateDeposit_OptimisticLocking_NullVersion() throws IOException {
+        // GIVEN
         Deposit deposit = new Deposit();
         deposit.setDepositStatus(DepositStatus.SUBMITTED);
         client.createObject(deposit);
@@ -164,6 +176,7 @@ public class ElidePassClientTest extends PassClientTest {
         updateDep1.setDepositStatus(DepositStatus.FAILED);
         client.updateObject(updateDep1);
 
+        // WHEN/THEN
         IOException ioException = assertThrows(IOException.class, () -> {
             updateDep2.setDepositStatus(DepositStatus.ACCEPTED);
             ReflectionTestUtils.setField(updateDep2, "version", null);

--- a/pass-core-main/src/test/java/org/eclipse/pass/object/ElidePassClientTest.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/object/ElidePassClientTest.java
@@ -29,6 +29,7 @@ import org.eclipse.pass.object.model.Submission;
 import org.eclipse.pass.object.model.SubmissionStatus;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.util.ReflectionTestUtils;
 
 public class ElidePassClientTest extends PassClientTest {
     @Autowired
@@ -67,6 +68,34 @@ public class ElidePassClientTest extends PassClientTest {
     }
 
     @Test
+    public void testUpdateSubmission_OptimisticLocking_NullVersion() throws IOException {
+        Submission submission = new Submission();
+        submission.setAggregatedDepositStatus(AggregatedDepositStatus.NOT_STARTED);
+        submission.setSubmissionStatus(SubmissionStatus.DRAFT);
+        submission.setSubmitterName("Bessie");
+        client.createObject(submission);
+
+        Submission updateSub1 = client.getObject(submission.getClass(), submission.getId());
+        Submission updateSub2 = client.getObject(submission.getClass(), submission.getId());
+
+        updateSub1.setSource(Source.OTHER);
+        updateSub1.setSubmissionStatus(SubmissionStatus.SUBMITTED);
+
+        client.updateObject(updateSub1);
+
+        IOException ioException = assertThrows(IOException.class, () -> {
+            updateSub2.setSource(null);
+            updateSub2.setSubmissionStatus(SubmissionStatus.CHANGES_REQUESTED);
+            ReflectionTestUtils.setField(updateSub2, "version", null);
+            client.updateObject(updateSub2);
+        });
+
+        assertTrue(ioException.getMessage().startsWith("Failed to update object: 409 " +
+            "{\"errors\":[{\"detail\":\"Optimistic lock check failed for Submission [ID="));
+        assertTrue(ioException.getMessage().endsWith("]. Request version: null, Stored version: 1\"}]}"));
+    }
+
+    @Test
     public void testUpdateDeposit_OptimisticLocking() throws IOException {
         Deposit deposit = new Deposit();
         deposit.setDepositStatus(DepositStatus.SUBMITTED);
@@ -86,5 +115,28 @@ public class ElidePassClientTest extends PassClientTest {
         assertTrue(ioException.getMessage().startsWith("Failed to update object: 409 " +
             "{\"errors\":[{\"detail\":\"Optimistic lock check failed for Deposit [ID="));
         assertTrue(ioException.getMessage().endsWith("]. Request version: 0, Stored version: 1\"}]}"));
+    }
+
+    @Test
+    public void testUpdateDeposit_OptimisticLocking_NullVersion() throws IOException {
+        Deposit deposit = new Deposit();
+        deposit.setDepositStatus(DepositStatus.SUBMITTED);
+        client.createObject(deposit);
+
+        Deposit updateDep1 = client.getObject(deposit.getClass(), deposit.getId());
+        Deposit updateDep2 = client.getObject(deposit.getClass(), deposit.getId());
+
+        updateDep1.setDepositStatus(DepositStatus.FAILED);
+        client.updateObject(updateDep1);
+
+        IOException ioException = assertThrows(IOException.class, () -> {
+            updateDep2.setDepositStatus(DepositStatus.ACCEPTED);
+            ReflectionTestUtils.setField(updateDep2, "version", null);
+            client.updateObject(updateDep2);
+        });
+
+        assertTrue(ioException.getMessage().startsWith("Failed to update object: 409 " +
+            "{\"errors\":[{\"detail\":\"Optimistic lock check failed for Deposit [ID="));
+        assertTrue(ioException.getMessage().endsWith("]. Request version: null, Stored version: 1\"}]}"));
     }
 }

--- a/pass-core-main/src/test/java/org/eclipse/pass/object/ElidePassClientTest.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/object/ElidePassClientTest.java
@@ -19,7 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
-import javax.persistence.OptimisticLockException;
 
 import com.yahoo.elide.RefreshableElide;
 import org.eclipse.pass.object.model.AggregatedDepositStatus;
@@ -56,15 +55,15 @@ public class ElidePassClientTest extends PassClientTest {
 
         client.updateObject(updateSub1);
 
-        RuntimeException runtimeException = assertThrows(RuntimeException.class, () -> {
+        IOException ioException = assertThrows(IOException.class, () -> {
             updateSub2.setSource(null);
             updateSub2.setSubmissionStatus(SubmissionStatus.CHANGES_REQUESTED);
             client.updateObject(updateSub2);
         });
 
-        OptimisticLockException optimisticLockException = (OptimisticLockException) runtimeException.getCause();
-        assertTrue(optimisticLockException.getMessage().startsWith("Optimistic lock check failed for Submission [ID="));
-        assertTrue(optimisticLockException.getMessage().endsWith("]. Request version: 0, Stored version: 1"));
+        assertTrue(ioException.getMessage().startsWith("Failed to update object: 409 " +
+            "{\"errors\":[{\"detail\":\"Optimistic lock check failed for Submission [ID="));
+        assertTrue(ioException.getMessage().endsWith("]. Request version: 0, Stored version: 1\"}]}"));
     }
 
     @Test
@@ -79,13 +78,13 @@ public class ElidePassClientTest extends PassClientTest {
         updateDep1.setDepositStatus(DepositStatus.FAILED);
         client.updateObject(updateDep1);
 
-        RuntimeException runtimeException = assertThrows(RuntimeException.class, () -> {
+        IOException ioException = assertThrows(IOException.class, () -> {
             updateDep2.setDepositStatus(DepositStatus.ACCEPTED);
             client.updateObject(updateDep2);
         });
 
-        OptimisticLockException optimisticLockException = (OptimisticLockException) runtimeException.getCause();
-        assertTrue(optimisticLockException.getMessage().startsWith("Optimistic lock check failed for Deposit [ID="));
-        assertTrue(optimisticLockException.getMessage().endsWith("]. Request version: 0, Stored version: 1"));
+        assertTrue(ioException.getMessage().startsWith("Failed to update object: 409 " +
+            "{\"errors\":[{\"detail\":\"Optimistic lock check failed for Deposit [ID="));
+        assertTrue(ioException.getMessage().endsWith("]. Request version: 0, Stored version: 1\"}]}"));
     }
 }

--- a/pass-core-main/src/test/java/org/eclipse/pass/object/ElidePassClientTest.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/object/ElidePassClientTest.java
@@ -49,11 +49,12 @@ public class ElidePassClientTest extends PassClientTest {
         client.createObject(submission);
 
         Submission updateSub1 = client.getObject(submission.getClass(), submission.getId());
-        Submission updateSub2 = client.getObject(submission.getClass(), submission.getId());
+        // This is needed to simulate second client get because client.getObject returns same instance of Submission
+        // in this test.
+        Submission updateSub2 = new Submission(updateSub1);
 
         updateSub1.setSource(Source.OTHER);
         updateSub1.setSubmissionStatus(SubmissionStatus.SUBMITTED);
-
         client.updateObject(updateSub1);
 
         IOException ioException = assertThrows(IOException.class, () -> {
@@ -102,7 +103,9 @@ public class ElidePassClientTest extends PassClientTest {
         client.createObject(deposit);
 
         Deposit updateDep1 = client.getObject(deposit.getClass(), deposit.getId());
-        Deposit updateDep2 = client.getObject(deposit.getClass(), deposit.getId());
+        // This is needed to simulate second client get because client.getObject returns same instance of Deposit
+        // in this test.
+        Deposit updateDep2 = new Deposit(updateDep1);
 
         updateDep1.setDepositStatus(DepositStatus.FAILED);
         client.updateObject(updateDep1);

--- a/pass-core-main/src/test/java/org/eclipse/pass/object/PassClientTest.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/object/PassClientTest.java
@@ -50,7 +50,7 @@ import org.junit.jupiter.api.Test;
  * Tests must be written such that they can run in any order and handle objects already existing.
  */
 public abstract class PassClientTest extends IntegrationTest {
-    private PassClient client;
+    protected PassClient client;
 
     protected abstract PassClient getNewClient();
 

--- a/pass-core-main/src/test/java/org/eclipse/pass/user/UserServiceTest.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/user/UserServiceTest.java
@@ -1,6 +1,7 @@
 package org.eclipse.pass.user;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -88,6 +89,7 @@ public class UserServiceTest extends ShibIntegrationTest {
         try (PassClient client = PassClient.newInstance(refreshableElide)) {
             client.createObject(submission);
         }
+        assertEquals(0, submission.getVersion());
 
         Token token = userTokenFactory.forPassResource("submission", submission.getId(), mailto);
 
@@ -114,9 +116,10 @@ public class UserServiceTest extends ShibIntegrationTest {
         try (PassClient client = PassClient.newInstance(refreshableElide)) {
             submission = client.getObject(submission.getClass(), submission.getId());
 
-            assertEquals(null, submission.getSubmitterName());
-            assertEquals(null, submission.getSubmitterEmail());
+            assertNull(submission.getSubmitterName());
+            assertNull(submission.getSubmitterEmail());
             assertEquals(submitter.getId(), submission.getSubmitter().getId());
+            assertEquals(1, submission.getVersion());
         }
     }
 }

--- a/pass-core-object-service/src/main/java/org/eclipse/pass/object/ElidePassClient.java
+++ b/pass-core-object-service/src/main/java/org/eclipse/pass/object/ElidePassClient.java
@@ -178,11 +178,7 @@ public class ElidePassClient implements PassClient {
 
         String id = elide.getMapper().readJsonApiDocument(response.getBody()).getData().getSingleValue().getId();
         settings.getDictionary().setId(obj, id);
-        Object version = elide.getMapper().readJsonApiDocument(response.getBody()).getData().getSingleValue()
-            .getAttributes().get("version");
-        if (Objects.nonNull(version)) {
-            settings.getDictionary().setValue(obj, "version", version);
-        }
+        setVersionIfNeeded(response, obj);
     }
 
     @Override
@@ -197,6 +193,16 @@ public class ElidePassClient implements PassClient {
 
         if (code < 200 || code > 204) {
             throw new IOException("Failed to update object: " + code + " " + response.getBody());
+        }
+
+        setVersionIfNeeded(response, obj);
+    }
+
+    private <T extends PassEntity> void setVersionIfNeeded(ElideResponse response, T obj) throws IOException {
+        Object version = elide.getMapper().readJsonApiDocument(response.getBody()).getData().getSingleValue()
+            .getAttributes().get("version");
+        if (Objects.nonNull(version)) {
+            settings.getDictionary().setValue(obj, "version", version);
         }
     }
 

--- a/pass-core-object-service/src/main/java/org/eclipse/pass/object/ElidePassClient.java
+++ b/pass-core-object-service/src/main/java/org/eclipse/pass/object/ElidePassClient.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
@@ -177,6 +178,11 @@ public class ElidePassClient implements PassClient {
 
         String id = elide.getMapper().readJsonApiDocument(response.getBody()).getData().getSingleValue().getId();
         settings.getDictionary().setId(obj, id);
+        Object version = elide.getMapper().readJsonApiDocument(response.getBody()).getData().getSingleValue()
+            .getAttributes().get("version");
+        if (Objects.nonNull(version)) {
+            settings.getDictionary().setValue(obj, "version", version);
+        }
     }
 
     @Override

--- a/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/Deposit.java
+++ b/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/Deposit.java
@@ -20,6 +20,7 @@ import javax.persistence.Convert;
 import javax.persistence.Entity;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
+import javax.persistence.Version;
 
 import com.yahoo.elide.annotation.Include;
 import org.eclipse.pass.object.converter.DepositStatusToStringConverter;
@@ -36,6 +37,9 @@ import org.eclipse.pass.object.converter.DepositStatusToStringConverter;
 @Entity
 @Table(name = "pass_deposit")
 public class Deposit extends PassEntity {
+
+    @Version
+    private Long version;
 
     /**
      * A URL or some kind of reference that can be dereferenced, entity body parsed, and used to determine the status
@@ -86,6 +90,13 @@ public class Deposit extends PassEntity {
         this.submission = deposit.submission;
         this.repository = deposit.repository;
         this.repositoryCopy = deposit.repositoryCopy;
+    }
+
+    /**
+     * @return the version for optimistic locking
+     */
+    public Long getVersion() {
+        return version;
     }
 
     /**
@@ -170,9 +181,12 @@ public class Deposit extends PassEntity {
             return false;
         }
         Deposit other = (Deposit) obj;
-        return depositStatus == other.depositStatus && Objects.equals(depositStatusRef, other.depositStatusRef)
-                && Objects.equals(repository, other.repository) && Objects.equals(repositoryCopy, other.repositoryCopy)
-                && Objects.equals(submission, other.submission);
+        return depositStatus == other.depositStatus
+            && Objects.equals(depositStatusRef, other.depositStatusRef)
+            && Objects.equals(repository, other.repository)
+            && Objects.equals(repositoryCopy, other.repositoryCopy)
+            && Objects.equals(submission, other.submission)
+            && Objects.equals(version, other.version);
     }
 
     @Override

--- a/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/Deposit.java
+++ b/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/Deposit.java
@@ -90,6 +90,7 @@ public class Deposit extends PassEntity {
         this.submission = deposit.submission;
         this.repository = deposit.repository;
         this.repositoryCopy = deposit.repositoryCopy;
+        this.version = deposit.version;
     }
 
     /**

--- a/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/Submission.java
+++ b/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/Submission.java
@@ -166,6 +166,7 @@ public class Submission extends PassEntity {
         this.preparers = new ArrayList<User>(submission.preparers);
         this.grants = new ArrayList<Grant>(submission.grants);
         this.effectivePolicies = new ArrayList<>(submission.effectivePolicies);
+        this.version = submission.version;
     }
 
     /**

--- a/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/Submission.java
+++ b/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/Submission.java
@@ -26,6 +26,7 @@ import javax.persistence.Entity;
 import javax.persistence.ManyToMany;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
+import javax.persistence.Version;
 
 import com.yahoo.elide.annotation.CreatePermission;
 import com.yahoo.elide.annotation.Include;
@@ -46,6 +47,9 @@ import org.eclipse.pass.object.converter.SubmissionStatusToStringConverter;
 @Entity
 @Table(name = "pass_submission")
 public class Submission extends PassEntity {
+
+    @Version
+    private Long version;
 
     /**
      * Stringified JSON representation of metadata captured by the relevant repository forms
@@ -162,6 +166,13 @@ public class Submission extends PassEntity {
         this.preparers = new ArrayList<User>(submission.preparers);
         this.grants = new ArrayList<Grant>(submission.grants);
         this.effectivePolicies = new ArrayList<>(submission.effectivePolicies);
+    }
+
+    /**
+     * @return the version for optimistic locking
+     */
+    public Long getVersion() {
+        return version;
     }
 
     /**
@@ -388,15 +399,21 @@ public class Submission extends PassEntity {
         }
         Submission other = (Submission) obj;
         return aggregatedDepositStatus == other.aggregatedDepositStatus
-                && Objects.equals(effectivePolicies, other.effectivePolicies) && Objects.equals(grants, other.grants)
-                && Objects.equals(metadata, other.metadata) && Objects.equals(preparers, other.preparers)
-                && Objects.equals(publication, other.publication) && Objects.equals(repositories, other.repositories)
-                && source == other.source && submissionStatus == other.submissionStatus
-                && Objects.equals(submitted, other.submitted)
-                && Objects.equals(submittedDate == null ? null : submittedDate.toInstant(),
-                        other.submittedDate == null ? null : other.submittedDate.toInstant())
-                && Objects.equals(submitter, other.submitter) && Objects.equals(submitterEmail, other.submitterEmail)
-                && Objects.equals(submitterName, other.submitterName);
+            && Objects.equals(effectivePolicies, other.effectivePolicies)
+            && Objects.equals(grants, other.grants)
+            && Objects.equals(metadata, other.metadata)
+            && Objects.equals(preparers, other.preparers)
+            && Objects.equals(publication, other.publication)
+            && Objects.equals(repositories, other.repositories)
+            && source == other.source
+            && submissionStatus == other.submissionStatus
+            && Objects.equals(submitted, other.submitted)
+            && Objects.equals(submittedDate == null ? null : submittedDate.toInstant(),
+                other.submittedDate == null ? null : other.submittedDate.toInstant())
+            && Objects.equals(submitter, other.submitter)
+            && Objects.equals(submitterEmail, other.submitterEmail)
+            && Objects.equals(submitterName, other.submitterName)
+            && Objects.equals(version, other.version);
     }
 
     @Override


### PR DESCRIPTION
https://github.com/eclipse-pass/main/issues/715

This adds the `@Version` version attribute to the Submission and Deposit entities to enable optimistic locking on updates.  Incrementing and setting the version values is handled by JPA/hibernate.

The elide lifecycle code is needed to handle the `Lost Update` scenario covered in the `ElidePassClientTest`.  This code is needed because of the way elide saves updates in the Patch handler.  It does not call `em.merge` because is sees the entities as managed.  So I put in the lifecycle hooks on updates for Submission and Deposit before flush to check the version of the request entity against what is in the database and handle appropriately.

The Elide configuration was also changed to return `200` for updates instead of `204`.  By doing this, the updated entity json is returned in the response.  This is important for versioned entities like Submission and Deposit so that the new version value can be set in the client's object from the response.

There will be another PR opened in pass-support for the pass-data-client to add the version attributes and to handle CONFLICT errors as needed, but I figured I'd open this for review now to get this solution checked.

https://github.com/eclipse-pass/pass-support/pull/57

And this PR in pass-ui:

https://github.com/eclipse-pass/pass-ui/pull/1209