### PR TITLE
Update the database for migration

### DIFF
--- a/pass-core-main/src/main/resources/db/changelog/changelog.yaml
+++ b/pass-core-main/src/main/resources/db/changelog/changelog.yaml
@@ -55,4 +55,21 @@ databaseChangeLog:
              path: /db/changelog/schema/postgres-pattern-indices.sql
              splitStatements: true
              stripComments: true
-
+  -  changeSet:
+       id:  6
+       author:  mark-patton
+       changes:
+         - sqlFile:
+             encoding: utf-8
+             path: /db/changelog/schema/long-text.sql
+             splitStatements: true
+             stripComments: true
+  -  changeSet:
+       id:  7
+       author:  mark-patton
+       changes:
+         - sqlFile:
+             encoding: utf-8
+             path: /db/changelog/schema/index-localkey.sql
+             splitStatements: true
+             stripComments: true

--- a/pass-core-main/src/main/resources/db/changelog/schema/index-localkey.sql
+++ b/pass-core-main/src/main/resources/db/changelog/schema/index-localkey.sql
@@ -1,0 +1,5 @@
+-- Index Grant.localKey
+CREATE INDEX pass_grant_localkey_ix ON public.pass_grant (localkey);
+
+-- Index Funder.localKey
+CREATE INDEX pass_funder_localkey_ix ON public.pass_funder (localkey);

--- a/pass-core-main/src/main/resources/db/changelog/schema/long-text.sql
+++ b/pass-core-main/src/main/resources/db/changelog/schema/long-text.sql
@@ -1,0 +1,11 @@
+
+-- Support long for File.descripton
+ALTER TABLE public.pass_file ALTER COLUMN description TYPE text;
+
+-- Support long Publication.title
+ALTER TABLE public.pass_publication ALTER COLUMN title TYPE text;
+
+-- Support long SubmissionEvent.comment
+ALTER TABLE public.pass_submission_event ALTER COLUMN comment TYPE text;
+
+


### PR DESCRIPTION
The colums SubmissionEvent.comment, File.description, and Publication.title need to support larger values. This pr changes those columns to text.

In addition Funder.localKey and Grant.localKey are indexed to support the grant loader which does queries on those values.