### PR TITLE
Make journal-title optional for JScholarship and required for NIHMS

### DIFF
--- a/pass-core-metadataschema-service/src/main/resources/schemas/jhu/global.json
+++ b/pass-core-metadataschema-service/src/main/resources/schemas/jhu/global.json
@@ -6,8 +6,7 @@
     "type": "object",
     "required": [
         "$schema",
-        "title",
-        "journal-title"
+        "title"
     ],
     "additionalProperties": false,
     "properties": {

--- a/pass-core-metadataschema-service/src/main/resources/schemas/jhu/global.json
+++ b/pass-core-metadataschema-service/src/main/resources/schemas/jhu/global.json
@@ -172,11 +172,12 @@
         "fields": {
             "title": {
                 "type": "textarea",
-                "label": "Article / Manuscript Title <small class=\"text-muted\">(required)</small>",
+                "label": "Article / Manuscript Title",
                 "placeholder": "Enter the manuscript title",
                 "rows": 2,
                 "cols": 100,
                 "hidden": false,
+                "readonly": true,
                 "order": 1
             },
             "journal-title": {
@@ -184,12 +185,14 @@
                 "label": "Journal Title",
                 "placeholder": "Enter the journal title",
                 "hidden": false,
+                "readonly": true,
                 "order": 2
             },
             "journal-NLMTA-ID": {
                 "type": "text",
                 "label": "Journal NLMTA ID",
                 "placeholder": "nlmta",
+                "readonly": true,
                 "order": 3
             },
             "volume": {
@@ -209,7 +212,31 @@
             "issns": {
                 "label": "<div>ISSN Information</div><hr/>",
                 "hidden": false,
+                "readonly": true,
+                "collapsible": false,
+                "collapsed": false,
                 "fieldClass": "",
+                "toolbar": {
+                    "actions": [{
+                        "action": "add",
+                        "enabled": false
+                    }]
+                },
+                "actionbar": {
+                    "actions": [{
+                        "action": "add",
+                        "enabled": false
+                    }, {
+                        "action": "remove",
+                        "enabled": false
+                    }, {
+                        "action": "up",
+                        "enabled": false
+                    }, {
+                        "action": "down",
+                        "enabled": false
+                    }]
+                },
                 "items": {
                     "label": "<span class=\"d-none\"></span>",
                     "fieldClass": "row",
@@ -252,6 +279,8 @@
             "authors": {
                 "label": "<div>Authors</div><hr/>",
                 "hidden": false,
+                "collapsible": false,
+                "collapsed": false,
                 "items": {
                     "label": "<span class=\"d-none\"></span>",
                     "fields": {

--- a/pass-core-metadataschema-service/src/main/resources/schemas/jhu/global.json
+++ b/pass-core-metadataschema-service/src/main/resources/schemas/jhu/global.json
@@ -181,14 +181,14 @@
             },
             "journal-title": {
                 "type": "text",
-                "label": "Journal Title <small class=\"text-muted\">(required)</small>",
+                "label": "Journal Title",
                 "placeholder": "Enter the journal title",
                 "hidden": false,
                 "order": 2
             },
             "journal-NLMTA-ID": {
                 "type": "text",
-                "label": "Journal NLMTA ID <small class=\"text-muted\">(optional)</small>",
+                "label": "Journal NLMTA ID",
                 "placeholder": "nlmta",
                 "order": 3
             },

--- a/pass-core-metadataschema-service/src/main/resources/schemas/jhu/nihms.json
+++ b/pass-core-metadataschema-service/src/main/resources/schemas/jhu/nihms.json
@@ -4,6 +4,9 @@
     "$id": "https://eclipse-pass.github.io/pass-metadata-schemas/schemas/jhu/nihms.json",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
+    "required": [
+        "journal-title"
+    ],
     "definitions": {
         "form": {
             "title": "NIH Manuscript Submission System (NIHMS) <br><p class='lead text-muted'>The following metadata fields will be part of the NIHMS submission.</p>",


### PR DESCRIPTION
This pr removes journal-title from the required list in global.json since it is optional for JScholarship. The individual repositories now must make it required when needed. In addition fields that are directly derived from Journal objects are marked as read only. The manuscript title is also marked read only since it is entered in the first step. In addition the `(required)` in labels is removed on read only fields. The toolbar and buttons for the read only issns are disabled.