### PR TITLE
Update pass parent version to be the current snapshot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.pass</groupId>
     <artifactId>eclipse-pass-parent</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>pass-core</artifactId>


### PR DESCRIPTION
I think this happened when doing some quick fixes in the previous release.