### PR TITLE
874 file deletion bug fix

### DIFF
--- a/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/PassFileServiceController.java
+++ b/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/PassFileServiceController.java
@@ -154,12 +154,22 @@ public class PassFileServiceController {
     }
 
     private boolean canUserDeleteFile(String principalName, String fileId, HttpServletRequest request) {
-        return (request.isUserInRole(WebSecurityRole.BACKEND.getValue()) ||
-                fileStorageService.checkUserDeletePermissions(principalName, fileId));
+        try {
+            return (request.isUserInRole(WebSecurityRole.BACKEND.getValue()) ||
+                    fileStorageService.checkUserDeletePermissions(fileId, principalName));
+        } catch (Exception e) {
+            LOG.error("File Service: Unable to determine user permissions to delete file: " + e);
+            return false;
+        }
     }
 
     private ResponseEntity<?> deleteFile(String fileId) {
-        fileStorageService.deleteFile(fileId);
-        return ResponseEntity.ok().body("Deleted");
+        try {
+            fileStorageService.deleteFile(fileId);
+            return ResponseEntity.ok().body("Deleted");
+        } catch (Exception e) {
+            LOG.error("File Service: Unable to delete file: " + e);
+            return ResponseEntity.notFound().build();
+        }
     }
 }

--- a/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/PassFileServiceController.java
+++ b/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/PassFileServiceController.java
@@ -169,7 +169,7 @@ public class PassFileServiceController {
             return ResponseEntity.ok().body("Deleted");
         } catch (Exception e) {
             LOG.error("File Service: Unable to delete file: " + e);
-            return ResponseEntity.notFound().build();
+            return ResponseEntity.badRequest().build();
         }
     }
 }

--- a/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/PassFileServiceController.java
+++ b/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/PassFileServiceController.java
@@ -155,8 +155,9 @@ public class PassFileServiceController {
 
     private boolean canUserDeleteFile(String principalName, String fileId, HttpServletRequest request) {
         try {
-            return (request.isUserInRole(WebSecurityRole.BACKEND.getValue()) ||
-                    fileStorageService.checkUserDeletePermissions(fileId, principalName));
+            return (fileStorageService.checkUserDeletePermissions(fileId, principalName) ||
+                    request.isUserInRole(WebSecurityRole.BACKEND.getValue())
+                    );
         } catch (Exception e) {
             LOG.error("File Service: Unable to determine user permissions to delete file: " + e);
             return false;

--- a/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/PassFileServiceController.java
+++ b/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/PassFileServiceController.java
@@ -149,15 +149,15 @@ public class PassFileServiceController {
             return ResponseEntity.notFound().build();
         }
 
-        return canUserDeleteFile(principalName, fileId, request) ? deleteFile(fileId) :
-                ResponseEntity.status(HttpStatus.FORBIDDEN).body("User does not have permission to delete this file.");
+        return canUserDeleteFile(principalName, fileId, request)
+            ? deleteFile(fileId)
+            : ResponseEntity.status(HttpStatus.FORBIDDEN).body("User does not have permission to delete this file.");
     }
 
     private boolean canUserDeleteFile(String principalName, String fileId, HttpServletRequest request) {
         try {
-            return (fileStorageService.checkUserDeletePermissions(fileId, principalName) ||
-                    request.isUserInRole(WebSecurityRole.BACKEND.getValue())
-                    );
+            boolean hasDeletePermission = fileStorageService.checkUserDeletePermissions(fileId, principalName);
+            return hasDeletePermission || request.isUserInRole(WebSecurityRole.BACKEND.getValue());
         } catch (Exception e) {
             LOG.error("File Service: Unable to determine user permissions to delete file: " + e);
             return false;

--- a/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/storage/FileStorageService.java
+++ b/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/storage/FileStorageService.java
@@ -359,6 +359,7 @@ public class FileStorageService {
      * file path. When using S3, this will provide the path of the file in the S3 bucket.
      * @param fileId The fileId of the file path to be returned.
      * @return The relative path of the file.
+     * @throws IOException If unable to get the relative path for a given fileId
      */
     public String getResourceFileRelativePath(String fileId) throws IOException {
         VersionDetails versionDetails = ocflRepository.describeVersion(ObjectVersionId.head(fileId));


### PR DESCRIPTION
There was a bug in the file service which was not deleting a file for an owner of a file. The ITs still passed because the ITs use BACKEND as the user. This user has permission to delete all files and therefore did not reach the point of the exception that was being thrown. 

Notable Changes:

- Fix for the bug
- Added exceptions to better handle when an error occurs on file deletion and permission checks.

Notes: Discussed and went over the changes with @jabrah. I needed to rebuild pass-ui in order to smoke test, but John said he would check this for me when reviewing this PR. 