### PR TITLE
Add delete permissions on File models

### DIFF
--- a/pass-core-main/src/test/java/org/eclipse/pass/main/security/AccessControlTest.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/main/security/AccessControlTest.java
@@ -386,7 +386,7 @@ public class AccessControlTest extends ShibIntegrationTest {
 
             Response response = client.newCall(request).execute();
 
-            check(response, 403);
+            check(response, 204);
         }
     }
 

--- a/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/File.java
+++ b/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/File.java
@@ -23,6 +23,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
 import com.yahoo.elide.annotation.CreatePermission;
+import com.yahoo.elide.annotation.DeletePermission;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.UpdatePermission;
 import org.eclipse.pass.object.converter.FileRoleToStringConverter;
@@ -35,6 +36,7 @@ import org.eclipse.pass.object.converter.FileRoleToStringConverter;
 
 @CreatePermission(expression = "User is Backend OR Object part of User Submission")
 @UpdatePermission(expression = "User is Backend OR Object part of User Submission")
+@DeletePermission(expression = "User is Backend OR Object part of User Submission")
 @Include
 @Entity
 @Table(name = "pass_file")


### PR DESCRIPTION
Part of https://github.com/eclipse-pass/main/issues/514

Would we want to first check if the uploaded bytes on the file system are gone (referenced in `file.uri`)?