### PR TITLE
Add Delete permissions for Submission and Publication

### DIFF
--- a/pass-core-main/src/test/java/org/eclipse/pass/main/security/AccessControlTest.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/main/security/AccessControlTest.java
@@ -327,7 +327,7 @@ public class AccessControlTest extends ShibIntegrationTest {
 
             Response response = client.newCall(request).execute();
 
-            check(response, 403);
+            check(response, 204);
         }
     }
 
@@ -373,7 +373,7 @@ public class AccessControlTest extends ShibIntegrationTest {
 
             Response response = client.newCall(request).execute();
 
-            check(response, 403);
+            check(response, 204);
         }
     }
 

--- a/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/Publication.java
+++ b/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/Publication.java
@@ -18,6 +18,7 @@ package org.eclipse.pass.object.model;
 import java.util.Objects;
 
 import com.yahoo.elide.annotation.CreatePermission;
+import com.yahoo.elide.annotation.DeletePermission;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.UpdatePermission;
 import jakarta.persistence.Column;
@@ -33,6 +34,7 @@ import jakarta.persistence.Table;
 
 @CreatePermission(expression = "User is Backend OR User is Submitter")
 @UpdatePermission(expression = "User is Backend OR User is Submitter")
+@DeletePermission(expression = "User is Backend OR User is Submitter")
 @Include
 @Entity
 @Table(name = "pass_publication")

--- a/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/Submission.java
+++ b/pass-core-object-service/src/main/java/org/eclipse/pass/object/model/Submission.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Objects;
 
 import com.yahoo.elide.annotation.CreatePermission;
+import com.yahoo.elide.annotation.DeletePermission;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.UpdatePermission;
 import jakarta.persistence.Column;
@@ -44,6 +45,7 @@ import org.eclipse.pass.object.converter.SubmissionStatusToStringConverter;
 
 @CreatePermission(expression = "User is Backend OR User is Submitter")
 @UpdatePermission(expression = "User is Backend OR Object part of User Submission")
+@DeletePermission(expression = "User is Backend OR Object part of User Submission")
 @Include
 @Entity
 @Table(name = "pass_submission")


### PR DESCRIPTION
## Question:

Are we OK with having a multi-step process for deleting and cleaning up a draft Submission and related entities? Deleting draft submissions does not produce SubmissionEvents (from the UI) so shouldn't trigger notification services.

To deleted a submission, a client would need to:
- Remove associated Files, since these Files reference the Submission)
- Remove the submission
- I think removing the submission's Publication, would be last, since the submission would hold a reference to it ?
  - only if no other submissions reference the Publication

There are multiple points of failure in this chain, none of which are really recoverable by the client, although chances of errors should be pretty low.


