### PR TITLE
Upgrade OCFL

### DIFF
--- a/pass-core-file-service/pom.xml
+++ b/pass-core-file-service/pom.xml
@@ -25,12 +25,12 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>edu.wisc.library.ocfl</groupId>
+            <groupId>io.ocfl</groupId>
             <artifactId>ocfl-java-core</artifactId>
             <version>${ocfl.java.core.version}</version>
         </dependency>
         <dependency>
-            <groupId>edu.wisc.library.ocfl</groupId>
+            <groupId>io.ocfl</groupId>
             <artifactId>ocfl-java-aws</artifactId>
             <version>${ocfl.java.aws.version}</version>
             <exclusions>

--- a/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/storage/StorageConfiguration.java
+++ b/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/storage/StorageConfiguration.java
@@ -70,7 +70,7 @@ public class StorageConfiguration {
 
         String endpoint = storageProperties.getS3Endpoint().orElse(null);
         S3Client s3Client = StringUtils.isNotBlank(endpoint)
-            ? builder.endpointOverride(URI.create(endpoint)).build()
+            ? builder.endpointOverride(URI.create(endpoint)).forcePathStyle(true).build()
             : builder.build();
 
         if (s3Client.listBuckets().buckets().stream().noneMatch(b -> b.name().equals(bucketName))) {

--- a/pass-core-main/pom.xml
+++ b/pass-core-main/pom.xml
@@ -143,7 +143,7 @@
     </dependency>
 
     <dependency>
-      <groupId>edu.wisc.library.ocfl</groupId>
+      <groupId>io.ocfl</groupId>
       <artifactId>ocfl-java-api</artifactId>
       <version>${ocfl.java.core.version}</version>
     </dependency>
@@ -169,15 +169,8 @@
     </dependency>
 
     <dependency>
-      <groupId>io.findify</groupId>
-      <artifactId>s3mock_2.13</artifactId>
-      <version>${s3mock.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>commons-logging</groupId>
-          <artifactId>commons-logging</artifactId>
-        </exclusion>
-      </exclusions>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>localstack</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/pass-core-main/src/test/java/org/eclipse/pass/file/service/storage/FileStorageServiceTest.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/file/service/storage/FileStorageServiceTest.java
@@ -36,7 +36,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
-import edu.wisc.library.ocfl.api.exception.NotFoundException;
+import io.ocfl.api.exception.NotFoundException;
 import okhttp3.Credentials;
 import okhttp3.MediaType;
 import okhttp3.MultipartBody;
@@ -80,7 +80,7 @@ public class FileStorageServiceTest extends IntegrationTest {
 
     @Autowired protected PassFileServiceController passFileServiceController;
     @Autowired protected FileStorageService storageService;
-    @Autowired protected StorageConfiguration storageConfiguration;
+    @Autowired protected StorageProperties storageProperties;
 
     /**
      * Cleanup the FileStorageService after testing. Deletes the root directory.
@@ -88,7 +88,7 @@ public class FileStorageServiceTest extends IntegrationTest {
     @AfterAll
     protected void tearDown() throws IOException {
         Path tempDir = Paths.get(System.getProperty("java.io.tmpdir"));
-        String rootDirName = storageConfiguration.getStorageProperties().getStorageRootDir();
+        String rootDirName = storageProperties.getStorageRootDir();
         File tempRootDir = tempDir.resolve(rootDirName).toFile();
         deleteDirectory(tempRootDir);
     }
@@ -127,8 +127,8 @@ public class FileStorageServiceTest extends IntegrationTest {
                 Objects.requireNonNull(MEDIA_TYPE_TEXT).toString(), "Test Pass-core".getBytes()), USER_NAME);
 
         Path tempDir = Paths.get(System.getProperty("java.io.tmpdir"));
-        String rootDirName = storageConfiguration.getStorageProperties().getStorageRootDir();
-        String tempDirName = storageConfiguration.getStorageProperties().getStorageTempDir();
+        String rootDirName = storageProperties.getStorageRootDir();
+        String tempDirName = storageProperties.getStorageTempDir();
         int fileCount = Objects.requireNonNull(tempDir.resolve(Paths.get(rootDirName, tempDirName))
                 .toFile().listFiles()).length;
         assertEquals(0, fileCount);

--- a/pass-core-main/src/test/java/org/eclipse/pass/file/service/storage/StorageConfigurationTest.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/file/service/storage/StorageConfigurationTest.java
@@ -28,11 +28,11 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("default-test")
 public class StorageConfigurationTest extends IntegrationTest {
 
-    @Autowired private StorageConfiguration storageConfiguration;
+    @Autowired private StorageProperties storageProperties;
 
     @Test
     public void testDefaultValuesFromConfiguration() {
-        assertFalse(storageConfiguration.getStorageProperties().getStorageRootDir().isEmpty());
-        assertFalse(storageConfiguration.getStorageProperties().getStorageRootDir().contains("#{null}"));
+        assertFalse(storageProperties.getStorageRootDir().isEmpty());
+        assertFalse(storageProperties.getStorageRootDir().contains("#{null}"));
     }
 }

--- a/pass-core-main/src/test/resources/application-test-S3.yml
+++ b/pass-core-main/src/test/resources/application-test-S3.yml
@@ -9,4 +9,3 @@ pass:
     root-dir:
     s3-bucket-name: pass-core-file-s3-it
     s3-repo-prefix: pass-core-file-s3-it
-    s3-endpoint: http://localhost:8010

--- a/pom.xml
+++ b/pom.xml
@@ -75,16 +75,16 @@
   <properties>
     <maven-dependency-plugin.version>3.6.1</maven-dependency-plugin.version>
     <spring-boot-maven-plugin.version>3.2.2</spring-boot-maven-plugin.version>
+    <amazon.pom.version>2.25.16</amazon.pom.version>
     <elide.version>7.0.2</elide.version>
-    <amazon.sqs.version>2.1.1</amazon.sqs.version>
+    <amazon.sqs.version>2.1.2</amazon.sqs.version>
     <logback.version>1.4.14</logback.version>
     <slf4j.version>2.0.7</slf4j.version>
     <liquibase.version>4.26.0</liquibase.version>
     <rest-assured.version>5.4.0</rest-assured.version>
 
-    <!-- TODO major upgrade -->
-    <ocfl.java.core.version>1.5.0</ocfl.java.core.version>
-    <ocfl.java.aws.version>1.5.0</ocfl.java.aws.version>
+    <ocfl.java.core.version>2.0.1</ocfl.java.core.version>
+    <ocfl.java.aws.version>2.0.1</ocfl.java.aws.version>
 
     <javax.json.version>1.1.4</javax.json.version>
     <h2.version>2.2.224</h2.version>
@@ -133,6 +133,14 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
         <version>${spring-boot-maven-plugin.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>bom</artifactId>
+        <version>${amazon.pom.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -258,7 +266,7 @@
                 <ignoredUsedUndeclaredDependency>com.fasterxml.jackson.core:jackson-databind:</ignoredUsedUndeclaredDependency>
                 <ignoredUsedUndeclaredDependency>com.yahoo.elide::</ignoredUsedUndeclaredDependency>
                 <!-- These come from ocfl -->
-                <ignoredUsedUndeclaredDependency>edu.wisc.library.ocfl:ocfl-java-api:</ignoredUsedUndeclaredDependency>
+                <ignoredUsedUndeclaredDependency>io.ocfl:ocfl-java-api:</ignoredUsedUndeclaredDependency>
                 <ignoredUsedUndeclaredDependency>com.google.code.findbugs:jsr305:</ignoredUsedUndeclaredDependency>
                 <!-- These come from spring boot activemq artemis starter -->
                 <ignoredUsedUndeclaredDependency>org.apache.activemq:artemis-jakarta-server:</ignoredUsedUndeclaredDependency>
@@ -275,6 +283,8 @@
                 <!-- These come from aws sqs jar -->
                 <ignoredUsedUndeclaredDependency>com.amazonaws:aws-java-sdk-core:</ignoredUsedUndeclaredDependency>
                 <ignoredUsedUndeclaredDependency>com.amazonaws:aws-java-sdk-sqs:</ignoredUsedUndeclaredDependency>
+                <!-- These come from testcontainers junit-jupiter -->
+                <ignoredUsedUndeclaredDependency>org.testcontainers::</ignoredUsedUndeclaredDependency>
               </ignoredUsedUndeclaredDependencies>
               <ignoredUnusedDeclaredDependencies>
                 <!-- This is the elide starter jar -->
@@ -300,7 +310,7 @@
                 <ignoredNonTestScopedDependency>org.eclipse.pass:pass-core-file-service:jar:</ignoredNonTestScopedDependency>
                 <!-- This needs to stay compile scope to be included in pass-core exec jar -->
                 <ignoredNonTestScopedDependency>com.squareup.okhttp3:okhttp:</ignoredNonTestScopedDependency>
-                <ignoredNonTestScopedDependency>edu.wisc.library.ocfl:ocfl-java-api:</ignoredNonTestScopedDependency>
+                <ignoredNonTestScopedDependency>io.ocfl:ocfl-java-api:</ignoredNonTestScopedDependency>
                 <ignoredNonTestScopedDependency>commons-io:commons-io:</ignoredNonTestScopedDependency>
                 <ignoredNonTestScopedDependency>com.fasterxml.jackson.core:jackson-*:</ignoredNonTestScopedDependency>
               </ignoredNonTestScopedDependencies>


### PR DESCRIPTION
This PR upgrades OCFL to latest version.  Notice the package change from `edu.wisc.library.ocfl` to `io.ocfl` https://mvnrepository.com/artifact/edu.wisc.library.ocfl/ocfl-java-core/2.0.1 .  I could no longer find an ocfl repo under edu.wisc.  The OCFL repo now associated is this https://github.com/OCFL/ocfl-java.

I also cleaned up the OCFL configuration in the FileService by refactoring most of the wiring up into the `StorageConfiguration` class.  I also replaced S3Mock with localstack S3.

There is also localstack upgrade required in pass-docker:   https://github.com/eclipse-pass/pass-docker/pull/368