### PR TITLE
Make the SAML login processing URL configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Environment variables:
 * PASS_CORE_LOGOUT_DELETE_COOKIES="JSESSIONID /"
 * PASS_CORE_SP_ID=https://sp.pass/shibboleth
 * PASS_CORE_SP_ACS=http://localhost:8080/login/saml2/sso/pass
+* PASS_CORE_LOGIN_PROCESSING_PATH=/login/saml2/sso/pass
 * PASS_CORE_SP_KEY=classpath:saml2/sp-key.pem
 * PASS_CORE_SP_CERT=classpath:saml2/sp-cert.pem
 * PASS_CORE_SUBMISSION_EVENT_QUEUE=pass-submission-event
@@ -98,7 +99,8 @@ The `SUBMITTER` has full access to all other services.
 
 The `PASS_CORE_SP_KEY` and `PASS_CORE_SP_CERT` environment variables set the location of the keys used by pass-core to encrypt SAML communication.
 Use `PASS_CORE_SP_ID` to set the identifier of the pass-core SP, `PASS_CORE_IDP_METADATA` to set the location where IDP metadata can be retrieved,
-and `PASS_CORE_SP_ACS` for the Assertion Consumer Service of the SP.
+`PASS_CORE_SP_ACS` for the Assertion Consumer Service of the SP and `PASS_CORE_LOGIN_PROCESSING_PATH` to set the path for handling login from the IDP.
+Note that `PASS_CORE_SP_ACS` is a URL which must match the path specified in `PASS_CORE_LOGIN_PROCESSING_PATH`.
 
 The defaults are set such that the integration tests can run against a [SimpleSAMLphp based IDP](https://github.com/kenchan0130/docker-simplesamlphp/) using resources included in `saml2/`. These defaults should not be used in production.
 

--- a/pass-core-main/src/main/java/org/eclipse/pass/main/security/SecurityConfiguration.java
+++ b/pass-core-main/src/main/java/org/eclipse/pass/main/security/SecurityConfiguration.java
@@ -53,6 +53,9 @@ public class SecurityConfiguration {
     @Value("${pass.default-login-success-url}")
     private String defaultLoginSuccessUrl;
 
+    @Value("${pass.login-processing-path}")
+    private String loginProcessingPath;
+
     @Value("${pass.csp}")
     private String contentSecurityPolicy;
 
@@ -99,7 +102,9 @@ public class SecurityConfiguration {
                 (request, response, authException) ->  response.sendError(HttpStatus.UNAUTHORIZED.value(),
                         HttpStatus.UNAUTHORIZED.getReasonPhrase()))));
 
-        http.saml2Login(s -> s.defaultSuccessUrl(defaultLoginSuccessUrl));
+        http.saml2Login(s -> s.defaultSuccessUrl(defaultLoginSuccessUrl).
+                        loginProcessingUrl(loginProcessingPath));
+
         http.saml2Metadata(Customizer.withDefaults());
         http.saml2Logout(Customizer.withDefaults());
 

--- a/pass-core-main/src/main/resources/application.yaml
+++ b/pass-core-main/src/main/resources/application.yaml
@@ -112,6 +112,7 @@ pass:
     sqs: ${PASS_CORE_USE_SQS:false}
     embed: ${PASS_CORE_EMBED_JMS_BROKER:true}
   default-login-success-url: ${PASS_CORE_DEFAULT_LOGIN_SUCCESS:/app/}
+  login-processing-path: ${PASS_CORE_LOGIN_PROCESSING_PATH:/login/saml2/sso/{registrationId}}
   logout-delete-cookies: ${PASS_CORE_LOGOUT_DELETE_COOKIES:JSESSIONID /}
   logout-success-url: ${PASS_CORE_LOGOUT_SUCCESS:/login}
   policy:


### PR DESCRIPTION
The SAML login processing URL must be manually configured to match the ACS URL sent to the IDP.