### PR TITLE
Add metadata schema for InvenioRDM along with a test

### DIFF
--- a/pass-core-metadataschema-service/src/main/resources/schemas/jhu/inveniordm.json
+++ b/pass-core-metadataschema-service/src/main/resources/schemas/jhu/inveniordm.json
@@ -1,0 +1,30 @@
+{
+    "title": "InvenioRDM schema",
+    "description": "InvenioRDM-specific metadata requirements",
+    "$id": "https://eclipse-pass.github.io/pass-metadata-schemas/schemas/jhu/inveniordm.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "definitions": {
+        "form": {
+            "title": "InvenioRDM <br><p class='lead text-muted'>Deposit requirements for InvenioRDM</p>",
+            "type": "object",
+            "properties": {
+                "authors": {
+                    "$ref": "global.json#/properties/authors"
+                }
+            },
+            "required": ["authors", "publicationDate"]
+        },
+        "options": {
+            "$ref": "global.json#/options"
+        }
+    },
+    "allOf": [
+        {
+            "$ref": "global.json#"
+        },
+        {
+            "$ref": "#/definitions/form"
+        }
+    ]
+}

--- a/pass-core-metadataschema-service/src/test/java/org/eclipse/pass/metadataschema/SchemaInstanceTest.java
+++ b/pass-core-metadataschema-service/src/test/java/org/eclipse/pass/metadataschema/SchemaInstanceTest.java
@@ -198,4 +198,18 @@ class SchemaInstanceTest {
         assertEquals(expectedSchema.getSchema(), testSchema.getSchema());
     }
 
+    @Test
+    void dereferenceInvenioRDMTest() throws Exception {
+        InputStream irdm_is = SchemaInstanceTest.class
+                .getResourceAsStream("/schemas/jhu/inveniordm.json");
+
+        InputStream expected_is = SchemaInstanceTest.class
+                .getResourceAsStream("/schemas/jhu/inveniordm_deref.json");
+
+        SchemaInstance testSchema = new SchemaInstance(map.readTree(irdm_is));
+        SchemaInstance expectedSchema = new SchemaInstance(map.readTree(expected_is));
+        SchemaFetcher schemaFetcher = new SchemaFetcher(Mockito.mock(RefreshableElide.class));
+        testSchema.dereference(testSchema.getSchema(), schemaFetcher);
+        assertEquals(expectedSchema.getSchema(), testSchema.getSchema());
+    }
 }

--- a/pass-core-metadataschema-service/src/test/resources/schemas/jhu/inveniordm_deref.json
+++ b/pass-core-metadataschema-service/src/test/resources/schemas/jhu/inveniordm_deref.json
@@ -1,0 +1,504 @@
+{
+  "title": "InvenioRDM schema",
+  "description": "InvenioRDM-specific metadata requirements",
+  "$id": "https://eclipse-pass.github.io/pass-metadata-schemas/schemas/jhu/inveniordm.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "definitions": {
+    "form": {
+      "title": "InvenioRDM <br><p class='lead text-muted'>Deposit requirements for InvenioRDM</p>",
+      "type": "object",
+      "properties": {
+        "authors": {
+          "type": "array",
+          "title": "Authors of this article or manuscript",
+          "description": "List of authors and their associated ORCIDS, if available",
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "title": "Author",
+            "properties": {
+              "author": {
+                "type": "string"
+              },
+              "orcid": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "author"
+            ]
+          }
+        }
+      },
+      "required": [
+        "authors",
+        "publicationDate"
+      ]
+    },
+    "options": {
+      "fields": {
+        "title": {
+          "type": "textarea",
+          "label": "Article / Manuscript Title <small class=\"text-muted\">(required)</small>",
+          "placeholder": "Enter the manuscript title",
+          "rows": 2,
+          "cols": 100,
+          "hidden": false,
+          "order": 1
+        },
+        "journal-title": {
+          "type": "text",
+          "label": "Journal Title <small class=\"text-muted\">(required)</small>",
+          "placeholder": "Enter the journal title",
+          "hidden": false,
+          "order": 2
+        },
+        "journal-NLMTA-ID": {
+          "type": "text",
+          "label": "Journal NLMTA ID <small class=\"text-muted\">(optional)</small>",
+          "placeholder": "nlmta",
+          "order": 3
+        },
+        "volume": {
+          "type": "text",
+          "label": "Volume  <small class=\"text-muted\">(optional)</small>",
+          "placeholder": "Enter the volume",
+          "hidden": false,
+          "order": 4
+        },
+        "issue": {
+          "type": "text",
+          "label": "Issue  <small class=\"text-muted\">(optional)</small>",
+          "placeholder": "Enter issue",
+          "hidden": false,
+          "order": 5
+        },
+        "issns": {
+          "label": "<div>ISSN Information</div><hr/>",
+          "hidden": false,
+          "fieldClass": "",
+          "items": {
+            "label": "<span class=\"d-none\"></span>",
+            "fieldClass": "row",
+            "fields": {
+              "issn": {
+                "label": "ISSN",
+                "fieldClass": "body-text col-6 pull-left "
+              },
+              "pubType": {
+                "label": "Publication Type",
+                "fieldClass": "body-text col-6 pull-left md-pubtype",
+                "vertical": false,
+                "removeDefaultNone": true
+              }
+            }
+          },
+          "order": 6
+        },
+        "publisher": {
+          "type": "text",
+          "label": "Publisher <small class=\"text-muted\">(optional)</small>",
+          "placeholder": "Enter the Publisher",
+          "hidden": false,
+          "order": 7
+        },
+        "publicationDate": {
+          "type": "date",
+          "label": "Publication Date  <small class=\"text-muted\">(optional)</small>",
+          "hidden": false,
+          "order": 8
+        },
+        "abstract": {
+          "type": "textarea",
+          "label": "Abstract <small class=\"text-muted\">(optional)</small>",
+          "placeholder": "Enter abstract",
+          "fieldClass": "clearfix",
+          "hidden": false,
+          "order": 9
+        },
+        "authors": {
+          "label": "<div>Authors</div><hr/>",
+          "hidden": false,
+          "items": {
+            "label": "<span class=\"d-none\"></span>",
+            "fields": {
+              "author": {
+                "label": "Name",
+                "fieldClass": "body-text col-6 pull-left pl-0"
+              },
+              "orcid": {
+                "label": "ORCiD",
+                "fieldClass": "body-text col-6 pull-left pr-0"
+              }
+            }
+          },
+          "order": 10
+        },
+        "under-embargo": {
+          "type": "checkbox",
+          "rightLabel": "The material being submitted is published under an embargo.",
+          "fieldClass": "m-0 mt-4",
+          "hidden": false,
+          "order": 11
+        },
+        "Embargo-end-date": {
+          "type": "date",
+          "label": "Embargo End Date",
+          "helper": "<i>After the embargo end date, your submission manuscripts or article can be made public. <b>If this publication is not under embargo, please leave this field blank.<b></i>",
+          "helpersPosition": "above",
+          "placeholder": "dd/mm/yyyy",
+          "validate": true,
+          "inputType": "date",
+          "fieldClass": "date-time-picker",
+          "picker": {
+            "format": "MM/DD/YY",
+            "allowInputToggle": true
+          },
+          "order": 12,
+          "dependencies": {
+            "under-embargo": true
+          }
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "title": "JHU global schema",
+      "description": "Defines all possible metadata fields for PASS deposit",
+      "$id": "https://eclipse-pass.github.io/pass-metadata-schemas/schemas/jhu/global.json",
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "type": "object",
+      "required": [
+        "$schema",
+        "title",
+        "journal-title"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "$schema": {
+          "type": "string",
+          "title": "JSON schema",
+          "description": "The JSON schema that applies to the resulting metadata blob"
+        },
+        "agreements": {
+          "type": "object",
+          "title": "Agreements to deposit conditions",
+          "description": "Maps repository keys to the text or links containing the agreements accepted by the submitter",
+          "$comment": "This was formerly known as 'embargo', available only for JScholarship metadata",
+          "patternProperties": {
+            "^.+$": {
+              "type": "string",
+              "title": "Agreement",
+              "description": "Text or link agreed to for the given repository key",
+              "$comment": "Example: {'jScholarship': 'http://example.org/agreementText'}"
+            }
+          }
+        },
+        "abstract": {
+          "type": "string",
+          "title": "Abstract",
+          "description": "The abstract of the article or manuscript being submitted"
+        },
+        "agent_information": {
+          "type": "object",
+          "title": "User agent (browser) information",
+          "description": "Contains the identity and version of the user's browser",
+          "properties": {
+            "name": {
+              "type": "string",
+              "title": "User agent (browser) name"
+            },
+            "version": {
+              "type": "string",
+              "title": "User agent (browser) version"
+            }
+          }
+        },
+        "authors": {
+          "type": "array",
+          "title": "Authors of this article or manuscript",
+          "description": "List of authors and their associated ORCIDS, if available",
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "title": "Author",
+            "properties": {
+              "author": {
+                "type": "string"
+              },
+              "orcid": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "author"
+            ]
+          }
+        },
+        "doi": {
+          "type": "string",
+          "pattern": "^10\\..+?/.+?$",
+          "title": "DOI of article",
+          "description": "The DOI of the individual article or manuscript submitted"
+        },
+        "Embargo-end-date": {
+          "type": "string",
+          "format": "date",
+          "title": "Embargo end date",
+          "description": "Date at which the article or manuscript may be made public"
+        },
+        "hints": {
+          "type": "object",
+          "title": "Hints provided by the UI to backend services",
+          "description": "Hints have semantics shared by the UI and the backend that are intended to influence the backend processing of the submission.",
+          "additionalProperties": false,
+          "properties": {
+            "collection-tags": {
+              "type": "array",
+              "uniqueItems": true,
+              "title": "Tags impacting the collection used by Deposit Services for deposit",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "journal-NLMTA-ID": {
+          "type": "string",
+          "title": "NTMLA",
+          "description": "NLM identifier for a journal"
+        },
+        "journal-title": {
+          "type": "string",
+          "title": "Journal title",
+          "description": "Title of the journal the individual article or manuscript was submitted to"
+        },
+        "journal-title-short": {
+          "type": "string",
+          "title": "Short journal title",
+          "description": "Short journal title from CrossRef"
+        },
+        "issue": {
+          "type": "string",
+          "title": "Journal issue",
+          "description": "Issue number of the journal this article or manuscript was submitted to"
+        },
+        "issns": {
+          "type": "array",
+          "title": "ISSN information for the manuscript's journal",
+          "description": "List of ISSN numbers with optional publication type",
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "title": "ISSN info",
+            "properties": {
+              "issn": {
+                "type": "string",
+                "title": "ISSN "
+              },
+              "pubType": {
+                "type": "string",
+                "title": "publication type",
+                "enum": [
+                  "Print",
+                  "Online"
+                ]
+              }
+            }
+          }
+        },
+        "publisher": {
+          "type": "string",
+          "title": "Publisher",
+          "description": "Publisher of the journal this article or manuscript was submitted to"
+        },
+        "publicationDate": {
+          "type": "string",
+          "title": "Publication Date",
+          "description": "Publication date of the journal or article this manuscript was submitted to",
+          "$comment": "This was formerly date-time format, but that appears too precise for values like 'Summer 2018'"
+        },
+        "title": {
+          "type": "string",
+          "title": "Article / Manuscript Title",
+          "description": "The title of the individual article or manuscript that was submitted"
+        },
+        "under-embargo": {
+          "type": "string",
+          "title": "Under Embargo",
+          "description": "Indicates wither the article or manuscript is under embargo",
+          "$comment": "This should probably be a boolean"
+        },
+        "volume": {
+          "type": "string",
+          "title": "Journal Volume",
+          "description": "journal volume this article or manuscript was published in"
+        }
+      },
+      "dependencies": {
+        "Embargo-end-date": [
+          "under-embargo"
+        ]
+      },
+      "options": {
+        "fields": {
+          "title": {
+            "type": "textarea",
+            "label": "Article / Manuscript Title <small class=\"text-muted\">(required)</small>",
+            "placeholder": "Enter the manuscript title",
+            "rows": 2,
+            "cols": 100,
+            "hidden": false,
+            "order": 1
+          },
+          "journal-title": {
+            "type": "text",
+            "label": "Journal Title <small class=\"text-muted\">(required)</small>",
+            "placeholder": "Enter the journal title",
+            "hidden": false,
+            "order": 2
+          },
+          "journal-NLMTA-ID": {
+            "type": "text",
+            "label": "Journal NLMTA ID <small class=\"text-muted\">(optional)</small>",
+            "placeholder": "nlmta",
+            "order": 3
+          },
+          "volume": {
+            "type": "text",
+            "label": "Volume  <small class=\"text-muted\">(optional)</small>",
+            "placeholder": "Enter the volume",
+            "hidden": false,
+            "order": 4
+          },
+          "issue": {
+            "type": "text",
+            "label": "Issue  <small class=\"text-muted\">(optional)</small>",
+            "placeholder": "Enter issue",
+            "hidden": false,
+            "order": 5
+          },
+          "issns": {
+            "label": "<div>ISSN Information</div><hr/>",
+            "hidden": false,
+            "fieldClass": "",
+            "items": {
+              "label": "<span class=\"d-none\"></span>",
+              "fieldClass": "row",
+              "fields": {
+                "issn": {
+                  "label": "ISSN",
+                  "fieldClass": "body-text col-6 pull-left "
+                },
+                "pubType": {
+                  "label": "Publication Type",
+                  "fieldClass": "body-text col-6 pull-left md-pubtype",
+                  "vertical": false,
+                  "removeDefaultNone": true
+                }
+              }
+            },
+            "order": 6
+          },
+          "publisher": {
+            "type": "text",
+            "label": "Publisher <small class=\"text-muted\">(optional)</small>",
+            "placeholder": "Enter the Publisher",
+            "hidden": false,
+            "order": 7
+          },
+          "publicationDate": {
+            "type": "date",
+            "label": "Publication Date  <small class=\"text-muted\">(optional)</small>",
+            "hidden": false,
+            "order": 8
+          },
+          "abstract": {
+            "type": "textarea",
+            "label": "Abstract <small class=\"text-muted\">(optional)</small>",
+            "placeholder": "Enter abstract",
+            "fieldClass": "clearfix",
+            "hidden": false,
+            "order": 9
+          },
+          "authors": {
+            "label": "<div>Authors</div><hr/>",
+            "hidden": false,
+            "items": {
+              "label": "<span class=\"d-none\"></span>",
+              "fields": {
+                "author": {
+                  "label": "Name",
+                  "fieldClass": "body-text col-6 pull-left pl-0"
+                },
+                "orcid": {
+                  "label": "ORCiD",
+                  "fieldClass": "body-text col-6 pull-left pr-0"
+                }
+              }
+            },
+            "order": 10
+          },
+          "under-embargo": {
+            "type": "checkbox",
+            "rightLabel": "The material being submitted is published under an embargo.",
+            "fieldClass": "m-0 mt-4",
+            "hidden": false,
+            "order": 11
+          },
+          "Embargo-end-date": {
+            "type": "date",
+            "label": "Embargo End Date",
+            "helper": "<i>After the embargo end date, your submission manuscripts or article can be made public. <b>If this publication is not under embargo, please leave this field blank.<b></i>",
+            "helpersPosition": "above",
+            "placeholder": "dd/mm/yyyy",
+            "validate": true,
+            "inputType": "date",
+            "fieldClass": "date-time-picker",
+            "picker": {
+              "format": "MM/DD/YY",
+              "allowInputToggle": true
+            },
+            "order": 12,
+            "dependencies": {
+              "under-embargo": true
+            }
+          }
+        }
+      }
+    },
+    {
+      "title": "InvenioRDM <br><p class='lead text-muted'>Deposit requirements for InvenioRDM</p>",
+      "type": "object",
+      "properties": {
+        "authors": {
+          "type": "array",
+          "title": "Authors of this article or manuscript",
+          "description": "List of authors and their associated ORCIDS, if available",
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "title": "Author",
+            "properties": {
+              "author": {
+                "type": "string"
+              },
+              "orcid": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "author"
+            ]
+          }
+        }
+      },
+      "required": [
+        "authors",
+        "publicationDate"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
As a first step for InvenioRDM suppport can just use a simple metadata schema that requires and author and publication date.

Later we may want to get more detailed name info from authors later on and so some work in pass-ui to get that work from the DOI.

Documented findings here: https://docs.google.com/document/d/1JllSJ48d14AvIVyhB0l0zUTcoj1vSB2oNlKRwi2wAVs/edit?usp=sharing