### PR TITLE
Turn on CSRF protection. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ docker run --name=idp -p 8090:8080 -e SIMPLESAMLPHP_SP_ENTITY_ID=https://sp.pass
 ```
 Note the volume mount which is set the user information appropriately for PASS.
 
+# CSRF protection
+
+Requests which have side effects (not a GET, HEAD, or OPTIONS and any request to /doi) are protected from CSRF through the use of a token. The client must provide a cookie XSRF-TOKEN and set a header X-XSRF-TOKEN to the same value. Clients can use any value they want. Browser clients will have the cookie value set by responses and so must first make a non-protected request.
+
 # App service
 
 The PASS application is available at `/app/` and `/` is redirected to `/app/`. Requests are resolved against the location given by the environment variable `PASS_CORE_APP_LOCATION`. If a request cannot be resolved, then `/app/index.html` will be returned.  This allows the user interface to handle paths which may not resolve to files.

--- a/pass-core-main/src/main/java/org/eclipse/pass/main/security/CsrfCookieFilter.java
+++ b/pass-core-main/src/main/java/org/eclipse/pass/main/security/CsrfCookieFilter.java
@@ -9,6 +9,9 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.security.web.csrf.CsrfToken;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+/**
+ * Ensure CSRF token cookie is added.
+ */
 public class CsrfCookieFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)

--- a/pass-core-main/src/main/java/org/eclipse/pass/main/security/CsrfCookieFilter.java
+++ b/pass-core-main/src/main/java/org/eclipse/pass/main/security/CsrfCookieFilter.java
@@ -1,0 +1,22 @@
+package org.eclipse.pass.main.security;
+
+import java.io.IOException;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+public class CsrfCookieFilter extends OncePerRequestFilter {
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        CsrfToken csrfToken = (CsrfToken) request.getAttribute("_csrf");
+        // Render the token value to a cookie by causing the deferred token to be loaded
+        csrfToken.getToken();
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/pass-core-main/src/main/java/org/eclipse/pass/main/security/CsrfCookieFilter.java
+++ b/pass-core-main/src/main/java/org/eclipse/pass/main/security/CsrfCookieFilter.java
@@ -10,7 +10,8 @@ import org.springframework.security.web.csrf.CsrfToken;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 /**
- * Ensure CSRF token cookie is added.
+ * Ensure CSRF token cookie is added. See
+ * https://docs.spring.io/spring-security/reference/servlet/exploits/csrf.html#csrf-integration-javascript-spa
  */
 public class CsrfCookieFilter extends OncePerRequestFilter {
     @Override

--- a/pass-core-main/src/main/java/org/eclipse/pass/main/security/SpaCsrfTokenRequestHandler.java
+++ b/pass-core-main/src/main/java/org/eclipse/pass/main/security/SpaCsrfTokenRequestHandler.java
@@ -9,6 +9,9 @@ import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
 import org.springframework.security.web.csrf.CsrfTokenRequestHandler;
 import org.springframework.security.web.csrf.XorCsrfTokenRequestAttributeHandler;
 
+/**
+ * Handle case of single page application which puts CSRF token cookie value into header.
+ */
 public class SpaCsrfTokenRequestHandler extends CsrfTokenRequestAttributeHandler {
     private final CsrfTokenRequestHandler delegate = new XorCsrfTokenRequestAttributeHandler();
 

--- a/pass-core-main/src/main/java/org/eclipse/pass/main/security/SpaCsrfTokenRequestHandler.java
+++ b/pass-core-main/src/main/java/org/eclipse/pass/main/security/SpaCsrfTokenRequestHandler.java
@@ -1,0 +1,46 @@
+package org.eclipse.pass.main.security;
+
+import java.util.function.Supplier;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
+import org.springframework.security.web.csrf.CsrfTokenRequestHandler;
+import org.springframework.security.web.csrf.XorCsrfTokenRequestAttributeHandler;
+
+public class SpaCsrfTokenRequestHandler extends CsrfTokenRequestAttributeHandler {
+    private final CsrfTokenRequestHandler delegate = new XorCsrfTokenRequestAttributeHandler();
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, Supplier<CsrfToken> csrfToken) {
+        /*
+         * Always use XorCsrfTokenRequestAttributeHandler to provide BREACH protection of
+         * the CsrfToken when it is rendered in the response body.
+         */
+        this.delegate.handle(request, response, csrfToken);
+    }
+
+    @Override
+    public String resolveCsrfTokenValue(HttpServletRequest request, CsrfToken csrfToken) {
+        /*
+         * If the request contains a request header, use CsrfTokenRequestAttributeHandler
+         * to resolve the CsrfToken. This applies when a single-page application includes
+         * the header value automatically, which was obtained via a cookie containing the
+         * raw CsrfToken.
+         */
+        String token = request.getHeader(csrfToken.getHeaderName());
+
+        if (token != null && !token.isEmpty()) {
+            return super.resolveCsrfTokenValue(request, csrfToken);
+        }
+
+        /*
+         * In all other cases (e.g. if the request contains a request parameter), use
+         * XorCsrfTokenRequestAttributeHandler to resolve the CsrfToken. This applies
+         * when a server-side rendered form includes the _csrf request parameter as a
+         * hidden input.
+         */
+        return this.delegate.resolveCsrfTokenValue(request, csrfToken);
+    }
+}

--- a/pass-core-main/src/main/java/org/eclipse/pass/main/security/SpaCsrfTokenRequestHandler.java
+++ b/pass-core-main/src/main/java/org/eclipse/pass/main/security/SpaCsrfTokenRequestHandler.java
@@ -8,9 +8,11 @@ import org.springframework.security.web.csrf.CsrfToken;
 import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
 import org.springframework.security.web.csrf.CsrfTokenRequestHandler;
 import org.springframework.security.web.csrf.XorCsrfTokenRequestAttributeHandler;
+import org.springframework.util.StringUtils;
 
 /**
- * Handle case of single page application which puts CSRF token cookie value into header.
+ * Handle case of single page application which puts CSRF token cookie value into header. See
+ * https://docs.spring.io/spring-security/reference/servlet/exploits/csrf.html#csrf-integration-javascript-spa
  */
 public class SpaCsrfTokenRequestHandler extends CsrfTokenRequestAttributeHandler {
     private final CsrfTokenRequestHandler delegate = new XorCsrfTokenRequestAttributeHandler();
@@ -34,7 +36,7 @@ public class SpaCsrfTokenRequestHandler extends CsrfTokenRequestAttributeHandler
          */
         String token = request.getHeader(csrfToken.getHeaderName());
 
-        if (token != null && !token.isEmpty()) {
+        if (StringUtils.hasText(token)) {
             return super.resolveCsrfTokenValue(request, csrfToken);
         }
 

--- a/pass-core-main/src/test/java/org/eclipse/pass/doi/service/DoiServiceTest.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/doi/service/DoiServiceTest.java
@@ -22,10 +22,12 @@ import org.eclipse.pass.object.PassClientResult;
 import org.eclipse.pass.object.PassClientSelector;
 import org.eclipse.pass.object.RSQL;
 import org.eclipse.pass.object.model.Journal;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public class DoiServiceTest extends SimpleIntegrationTest {
+    private static String credentials = Credentials.basic(BACKEND_USER, BACKEND_PASSWORD);
 
     @Autowired
     protected RefreshableElide refreshableElide;
@@ -34,8 +36,12 @@ public class DoiServiceTest extends SimpleIntegrationTest {
         return PassClient.newInstance(refreshableElide);
     }
 
-    private OkHttpClient httpClient = new OkHttpClient();
-    private String credentials = Credentials.basic(BACKEND_USER, BACKEND_PASSWORD);
+    private OkHttpClient httpClient;
+
+    @BeforeEach
+    protected void setupClient() throws IOException {
+        httpClient = newOkhttpClient();
+    }
 
     /**
      * throw in a "moo" doi, expect a 400 error
@@ -48,6 +54,7 @@ public class DoiServiceTest extends SimpleIntegrationTest {
 
         Request okHttpRequest = new Request.Builder()
             .url(url).header("Authorization", credentials)
+            .header("X-XSRF-TOKEN", getCsrfToken(httpClient))
             .build();
         Call call = httpClient.newCall(okHttpRequest);
         try (Response okHttpResponse = call.execute()) {
@@ -71,6 +78,7 @@ public class DoiServiceTest extends SimpleIntegrationTest {
 
         Request okHttpRequest = new Request.Builder()
             .url(url).header("Authorization", credentials)
+            .header("X-XSRF-TOKEN", getCsrfToken(httpClient))
             .build();
         Call call = httpClient.newCall(okHttpRequest);
         try (Response okHttpResponse = call.execute()) {
@@ -95,6 +103,7 @@ public class DoiServiceTest extends SimpleIntegrationTest {
 
         Request okHttpRequest = new Request.Builder()
             .url(url).header("Authorization", credentials)
+            .header("X-XSRF-TOKEN", getCsrfToken(httpClient))
             .build();
         Call call = httpClient.newCall(okHttpRequest);
         try (Response okHttpResponse = call.execute()) {
@@ -122,6 +131,7 @@ public class DoiServiceTest extends SimpleIntegrationTest {
 
         Request okHttpRequest = new Request.Builder()
             .url(url).header("Authorization", credentials)
+            .header("X-XSRF-TOKEN", getCsrfToken(httpClient))
             .build();
         Call call = httpClient.newCall(okHttpRequest);
         try (Response okHttpResponse = call.execute()) {
@@ -160,6 +170,7 @@ public class DoiServiceTest extends SimpleIntegrationTest {
 
             Request okHttpRequest = new Request.Builder()
                 .url(url).header("Authorization", credentials)
+                .header("X-XSRF-TOKEN", getCsrfToken(httpClient))
                 .build();
 
             Call call = httpClient.newCall(okHttpRequest);

--- a/pass-core-main/src/test/java/org/eclipse/pass/doi/service/DoiServiceTest.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/doi/service/DoiServiceTest.java
@@ -16,7 +16,7 @@ import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
-import org.eclipse.pass.main.IntegrationTest;
+import org.eclipse.pass.main.SimpleIntegrationTest;
 import org.eclipse.pass.object.PassClient;
 import org.eclipse.pass.object.PassClientResult;
 import org.eclipse.pass.object.PassClientSelector;
@@ -25,7 +25,7 @@ import org.eclipse.pass.object.model.Journal;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-public class DoiServiceTest extends IntegrationTest {
+public class DoiServiceTest extends SimpleIntegrationTest {
 
     @Autowired
     protected RefreshableElide refreshableElide;
@@ -52,9 +52,10 @@ public class DoiServiceTest extends IntegrationTest {
         Call call = httpClient.newCall(okHttpRequest);
         try (Response okHttpResponse = call.execute()) {
             assertEquals(400, okHttpResponse.code());
-            assert okHttpResponse.body() != null;
+            String body = okHttpResponse.body().string();
+            assert body != null;
             assertEquals("{\"error\":\"Supplied DOI is not in valid DOI format.\"}",
-                         okHttpResponse.body().string());
+                         body);
 
         }
     }
@@ -74,9 +75,10 @@ public class DoiServiceTest extends IntegrationTest {
         Call call = httpClient.newCall(okHttpRequest);
         try (Response okHttpResponse = call.execute()) {
             assertEquals(400, okHttpResponse.code());
-            assert okHttpResponse.body() != null;
+            String body = okHttpResponse.body().string();
+            assert body != null;
             assertEquals("{\"error\":\"Supplied DOI is not in valid DOI format.\"}",
-                         okHttpResponse.body().string());
+                         body);
 
         }
     }
@@ -97,9 +99,10 @@ public class DoiServiceTest extends IntegrationTest {
         Call call = httpClient.newCall(okHttpRequest);
         try (Response okHttpResponse = call.execute()) {
             assertEquals(404, okHttpResponse.code());
-            assert okHttpResponse.body() != null;
+            String body = okHttpResponse.body().string();
+            assert body != null;
             assertEquals("{\"error\":\"The resource for DOI 10.1212/abc.DEF could not be found on Crossref.\"}",
-                         okHttpResponse.body().string());
+                         body);
 
         }
     }
@@ -123,9 +126,10 @@ public class DoiServiceTest extends IntegrationTest {
         Call call = httpClient.newCall(okHttpRequest);
         try (Response okHttpResponse = call.execute()) {
             assertEquals(422, okHttpResponse.code());
-            assert okHttpResponse.body() != null;
+            String body = okHttpResponse.body().string();
+            assert body != null;
             assertEquals("{\"error\":\"Insufficient information to locate or specify a journal entry.\"}",
-                         okHttpResponse.body().string());
+                         body);
         }
     }
 
@@ -161,8 +165,9 @@ public class DoiServiceTest extends IntegrationTest {
             Call call = httpClient.newCall(okHttpRequest);
             try (Response okHttpResponse = call.execute()) {
                 assertEquals(200, okHttpResponse.code());
-                assert okHttpResponse.body() != null;
-                JsonReader jsonReader1 = Json.createReader(new StringReader(okHttpResponse.body().string()));
+                String body = okHttpResponse.body().string();
+                assert body != null;
+                JsonReader jsonReader1 = Json.createReader(new StringReader(body));
                 JsonObject successReport = jsonReader1.readObject();
                 jsonReader1.close();
                 assertNotNull(successReport.getString("journal-id"));
@@ -180,8 +185,9 @@ public class DoiServiceTest extends IntegrationTest {
             //verify that the returned object for the same request has the right id
             call = httpClient.newCall(okHttpRequest);
             try (Response okHttpResponse = call.execute()) {
-                assert okHttpResponse.body() != null;
-                JsonReader jsonReader2 = Json.createReader(new StringReader(okHttpResponse.body().string()));
+                String body = okHttpResponse.body().string();
+                assert body != null;
+                JsonReader jsonReader2 = Json.createReader(new StringReader(body));
                 JsonObject successReport = jsonReader2.readObject();
                 jsonReader2.close();
                 assertEquals(id, successReport.getString("journal-id"));

--- a/pass-core-main/src/test/java/org/eclipse/pass/file/service/storage/FileStorageServiceTest.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/file/service/storage/FileStorageServiceTest.java
@@ -37,7 +37,6 @@ import java.util.Map;
 import java.util.Objects;
 
 import io.ocfl.api.exception.NotFoundException;
-import okhttp3.Credentials;
 import okhttp3.MediaType;
 import okhttp3.MultipartBody;
 import okhttp3.OkHttpClient;
@@ -45,10 +44,11 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 import org.eclipse.pass.file.service.PassFileServiceController;
-import org.eclipse.pass.main.IntegrationTest;
+import org.eclipse.pass.main.SimpleIntegrationTest;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -68,19 +68,29 @@ import org.springframework.test.util.ReflectionTestUtils;
  * @see FileStorageService
  */
 @ExtendWith(MockitoExtension.class)
-public class FileStorageServiceTest extends IntegrationTest {
+public class FileStorageServiceTest extends SimpleIntegrationTest {
     protected final String USER_NAME = "USER1";
     protected final String USER_NAME2 = "USER2";
-    private final String credentialsBackend = Credentials.basic(BACKEND_USER, BACKEND_PASSWORD);
-    private final OkHttpClient httpClient = new OkHttpClient();
+
     public static final MediaType MEDIA_TYPE_TEXT
             = MediaType.parse("text/plain");
     public static final MediaType MEDIA_TYPE_APPLICATION
             = MediaType.parse("application/octet-stream");
 
+    private OkHttpClient httpClient;
+
     @Autowired protected PassFileServiceController passFileServiceController;
     @Autowired protected FileStorageService storageService;
     @Autowired protected StorageProperties storageProperties;
+
+    @BeforeEach
+    protected void setupClient() throws IOException {
+        httpClient = newOkhttpClient();
+    }
+
+    public String getCsrfToken() throws IOException {
+        return getCsrfToken(httpClient);
+    }
 
     /**
      * Cleanup the FileStorageService after testing. Deletes the root directory.
@@ -253,7 +263,7 @@ public class FileStorageServiceTest extends IntegrationTest {
                 .build();
         Request request = new Request.Builder()
                 .url(url)
-                .header("Authorization", credentialsBackend)
+                .header("Authorization", BACKEND_CREDENTIALS)
                 .get()
                 .build();
 
@@ -281,7 +291,8 @@ public class FileStorageServiceTest extends IntegrationTest {
         Request request = new Request.Builder()
                 .url(url)
                 .post(requestBody)
-                .addHeader("Authorization", credentialsBackend)
+                .addHeader("Authorization", BACKEND_CREDENTIALS)
+                .addHeader("X-XSRF-TOKEN", getCsrfToken())
                 .build();
 
         try (Response response = httpClient.newCall(request).execute()) {
@@ -311,7 +322,8 @@ public class FileStorageServiceTest extends IntegrationTest {
         Request request = new Request.Builder()
                 .url(url)
                 .post(requestBody)
-                .addHeader("Authorization", credentialsBackend)
+                .addHeader("Authorization", BACKEND_CREDENTIALS)
+                .addHeader("X-XSRF-TOKEN", getCsrfToken())
                 .build();
 
         try (Response response = httpClient.newCall(request).execute()) {
@@ -321,7 +333,7 @@ public class FileStorageServiceTest extends IntegrationTest {
 
             // Download
             Request dlRequest = new Request.Builder().url(url + "/" + id).
-                    addHeader("Authorization", credentialsBackend).build();
+                    addHeader("Authorization", BACKEND_CREDENTIALS).build();
 
             try (Response dlResponse = httpClient.newCall(dlRequest).execute()) {
                 assertEquals(HttpStatus.OK.value(), dlResponse.code());
@@ -352,7 +364,8 @@ public class FileStorageServiceTest extends IntegrationTest {
         Request request = new Request.Builder()
                 .url(url)
                 .post(requestBody)
-                .addHeader("Authorization", credentialsBackend)
+                .addHeader("Authorization", BACKEND_CREDENTIALS)
+                .addHeader("X-XSRF-TOKEN", getCsrfToken())
                 .build();
 
         try (Response response = httpClient.newCall(request).execute()) {
@@ -362,7 +375,7 @@ public class FileStorageServiceTest extends IntegrationTest {
 
             // Download
             Request dlRequest = new Request.Builder().url(url + "/" + id).
-                    addHeader("Authorization", credentialsBackend).build();
+                    addHeader("Authorization", BACKEND_CREDENTIALS).build();
 
             try (Response dlResponse = httpClient.newCall(dlRequest).execute()) {
                 assertEquals(HttpStatus.OK.value(), dlResponse.code());
@@ -389,7 +402,8 @@ public class FileStorageServiceTest extends IntegrationTest {
         Request request = new Request.Builder()
                 .url(url)
                 .post(requestBody)
-                .addHeader("Authorization", credentialsBackend)
+                .addHeader("Authorization", BACKEND_CREDENTIALS)
+                .addHeader("X-XSRF-TOKEN", getCsrfToken())
                 .build();
 
         try (Response response = httpClient.newCall(request).execute()) {
@@ -414,7 +428,8 @@ public class FileStorageServiceTest extends IntegrationTest {
         Request request = new Request.Builder()
                 .url(url)
                 .post(requestBody)
-                .addHeader("Authorization", credentialsBackend)
+                .addHeader("Authorization", BACKEND_CREDENTIALS)
+                .addHeader("X-XSRF-TOKEN", getCsrfToken())
                 .build();
 
         try (Response response = httpClient.newCall(request).execute()) {
@@ -436,7 +451,8 @@ public class FileStorageServiceTest extends IntegrationTest {
         Request request = new Request.Builder()
                 .url(url)
                 .delete()
-                .addHeader("Authorization", credentialsBackend)
+                .addHeader("Authorization", BACKEND_CREDENTIALS)
+                .addHeader("X-XSRF-TOKEN", getCsrfToken())
                 .build();
 
         try (Response response = httpClient.newCall(request).execute()) {
@@ -461,7 +477,8 @@ public class FileStorageServiceTest extends IntegrationTest {
         Request request = new Request.Builder()
                 .url(url)
                 .delete()
-                .addHeader("Authorization", credentialsBackend)
+                .addHeader("Authorization", BACKEND_CREDENTIALS)
+                .addHeader("X-XSRF-TOKEN", getCsrfToken())
                 .build();
 
         try (Response response = httpClient.newCall(request).execute()) {
@@ -485,7 +502,8 @@ public class FileStorageServiceTest extends IntegrationTest {
         Request request = new Request.Builder()
                 .url(url)
                 .delete()
-                .addHeader("Authorization", credentialsBackend)
+                .addHeader("Authorization", BACKEND_CREDENTIALS)
+                .addHeader("X-XSRF-TOKEN", getCsrfToken())
                 .build();
 
         try (Response response = httpClient.newCall(request).execute()) {

--- a/pass-core-main/src/test/java/org/eclipse/pass/file/service/storage/StorageConfigurationTest.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/file/service/storage/StorageConfigurationTest.java
@@ -17,7 +17,7 @@ package org.eclipse.pass.file.service.storage;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
-import org.eclipse.pass.main.IntegrationTest;
+import org.eclipse.pass.main.SimpleIntegrationTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ActiveProfiles;
@@ -26,7 +26,7 @@ import org.springframework.test.context.ActiveProfiles;
  * @author Russ Poetker (rpoetke1@jh.edu)
  */
 @ActiveProfiles("default-test")
-public class StorageConfigurationTest extends IntegrationTest {
+public class StorageConfigurationTest extends SimpleIntegrationTest {
 
     @Autowired private StorageProperties storageProperties;
 

--- a/pass-core-main/src/test/java/org/eclipse/pass/main/IntegrationTestBase.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/main/IntegrationTestBase.java
@@ -1,0 +1,80 @@
+package org.eclipse.pass.main;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.IOException;
+import java.net.CookieManager;
+import java.net.CookiePolicy;
+
+import okhttp3.CookieJar;
+import okhttp3.Credentials;
+import okhttp3.HttpUrl;
+import okhttp3.JavaNetCookieJar;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+public abstract class IntegrationTestBase {
+    public static final String BACKEND_USER = "backend";
+    public static final String BACKEND_PASSWORD = "moo";
+    public static final String BACKEND_CREDENTIALS = Credentials.basic(BACKEND_USER, BACKEND_PASSWORD);
+
+    public final static String JSON_API_CONTENT_TYPE = "application/vnd.api+json";
+    public final static MediaType JSON_API_MEDIA_TYPE = MediaType.parse("application/vnd.api+json; charset=utf-8");
+
+    /**
+     * @return Base URL for API.
+     */
+    public abstract String getBaseUrl();
+
+    /**
+     * @return OkhttpClient configured to save cookies
+     * @throws IOException
+     */
+    public OkHttpClient newOkhttpClient() throws IOException {
+        // Persist cookies for CSRF and SAML
+        // Follow redirects for SAML login
+
+        CookieManager cookieManager = new CookieManager();
+        cookieManager.setCookiePolicy(CookiePolicy.ACCEPT_ALL);
+        JavaNetCookieJar cookieJar = new JavaNetCookieJar(cookieManager);
+
+        return new OkHttpClient.Builder().cookieJar(cookieJar).build();
+    }
+
+    private String get_csrf_token(CookieJar jar) {
+        return jar.loadForRequest(HttpUrl.get(getBaseUrl())).stream().
+                filter(c -> c.name().equals("XSRF-TOKEN")).findFirst().map(c -> c.value()).orElse(null);
+    }
+
+    /**
+     * Returns the current CSRF token saved in the cookie jar.
+     * If it can't be found, generate a token as the backend user.
+     *
+     * @return Current CSRF token
+     * @throws IOException
+     */
+    public String getCsrfToken(OkHttpClient client) throws IOException {
+        String token = get_csrf_token(client.cookieJar());
+
+        // Make a request to get a token if needed
+        if (token == null) {
+            String url = getBaseUrl() + "data/grant";
+            Request request = new Request.Builder().url(url).header("Accept", JSON_API_CONTENT_TYPE)
+                    .addHeader("Content-Type", JSON_API_CONTENT_TYPE)
+                    .header("Authorization", BACKEND_CREDENTIALS).get().build();
+
+            Response response = client.newCall(request).execute();
+
+            assertEquals(200, response.code());
+        }
+
+        token = get_csrf_token(client.cookieJar());
+
+        assertNotNull(token);
+
+        return token;
+    }
+}

--- a/pass-core-main/src/test/java/org/eclipse/pass/main/JmsConfigurationTest.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/main/JmsConfigurationTest.java
@@ -36,7 +36,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jms.core.BrowserCallback;
 import org.springframework.jms.core.JmsTemplate;
 
-public class JmsConfigurationTest extends IntegrationTest {
+public class JmsConfigurationTest extends SimpleIntegrationTest {
     @Autowired
     private JmsTemplate jms;
 

--- a/pass-core-main/src/test/java/org/eclipse/pass/main/JmsSqsConfigurationTest.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/main/JmsSqsConfigurationTest.java
@@ -32,7 +32,7 @@ import software.amazon.awssdk.utils.AttributeMap;
     "spring.artemis.embedded.enabled=false",
     "pass.jms.sqs=true"
 })
-public class JmsSqsConfigurationTest extends IntegrationTest {
+public class JmsSqsConfigurationTest extends SimpleIntegrationTest {
 
     @Autowired private ConnectionFactory connectionFactory;
 

--- a/pass-core-main/src/test/java/org/eclipse/pass/main/JmsSqsEndpointConfigurationTest.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/main/JmsSqsEndpointConfigurationTest.java
@@ -33,7 +33,7 @@ import software.amazon.awssdk.utils.AttributeMap;
     "pass.jms.sqs=true",
     "aws.sqs.endpoint-override=http://testhost:8080"
 })
-public class JmsSqsEndpointConfigurationTest extends IntegrationTest {
+public class JmsSqsEndpointConfigurationTest extends SimpleIntegrationTest {
 
     @Autowired private ConnectionFactory connectionFactory;
 

--- a/pass-core-main/src/test/java/org/eclipse/pass/main/SimpleIntegrationTest.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/main/SimpleIntegrationTest.java
@@ -22,18 +22,16 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 
 /**
- * Run Elide with in memory database.
+ * Run with in memory database.
  */
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = Main.class,
-    properties = {"PASS_CORE_BACKEND_PASSWORD=test"})
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = Main.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public abstract class IntegrationTest {
-    public static final String BACKEND_USER = "backend";
-    public static final String BACKEND_PASSWORD = "test";
+public abstract class SimpleIntegrationTest extends IntegrationTestBase {
 
     @LocalServerPort
     private int port;
 
+    @Override
     public String getBaseUrl() {
         return "http://localhost:" + port + "/";
     }
@@ -43,7 +41,7 @@ public abstract class IntegrationTest {
     }
 
     @BeforeAll
-    void setup() {
+    public void setup() {
         RestAssured.port = port;
     }
 }

--- a/pass-core-main/src/test/java/org/eclipse/pass/main/security/AccessControlTest.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/main/security/AccessControlTest.java
@@ -130,10 +130,9 @@ public class AccessControlTest extends SamlIntegrationTest {
     public void testReadGrantsAsBackend() throws IOException {
         String url = getBaseUrl() + "data/grant";
 
-        String credentials = Credentials.basic(BACKEND_USER, BACKEND_PASSWORD);
-
         Request request = new Request.Builder().url(url).header("Accept", JSON_API_CONTENT_TYPE)
-                .addHeader("Content-Type", JSON_API_CONTENT_TYPE).header("Authorization", credentials).get().build();
+                .addHeader("Content-Type", JSON_API_CONTENT_TYPE)
+                .header("Authorization", BACKEND_CREDENTIALS).get().build();
 
         Response response = client.newCall(request).execute();
 
@@ -203,7 +202,9 @@ public class AccessControlTest extends SamlIntegrationTest {
             Request.Builder builder = new Request.Builder();
 
             Request request = builder.url(url).header("Accept", JSON_API_CONTENT_TYPE)
-                    .addHeader("Content-Type", JSON_API_CONTENT_TYPE).post(body).build();
+                    .addHeader("Content-Type", JSON_API_CONTENT_TYPE)
+                    .addHeader("X-XSRF-TOKEN", getCsrfToken())
+                    .post(body).build();
 
             Response response = client.newCall(request).execute();
 
@@ -218,7 +219,9 @@ public class AccessControlTest extends SamlIntegrationTest {
             Request.Builder builder = new Request.Builder();
 
             Request request = builder.url(url).header("Accept", JSON_API_CONTENT_TYPE)
-                    .addHeader("Content-Type", JSON_API_CONTENT_TYPE).patch(body).build();
+                    .addHeader("Content-Type", JSON_API_CONTENT_TYPE)
+                    .addHeader("X-XSRF-TOKEN", getCsrfToken())
+                    .patch(body).build();
 
             Response response = client.newCall(request).execute();
 
@@ -229,11 +232,62 @@ public class AccessControlTest extends SamlIntegrationTest {
             String url = getBaseUrl() + "data/submission/" + get_id(sub);
             Request.Builder builder = new Request.Builder();
 
-            Request request = builder.url(url).header("Accept", JSON_API_CONTENT_TYPE).delete().build();
+            Request request = builder.url(url).header("Accept", JSON_API_CONTENT_TYPE)
+                    .addHeader("X-XSRF-TOKEN", getCsrfToken())
+                    .delete().build();
 
             Response response = client.newCall(request).execute();
 
             check(response, 204);
+        }
+    }
+
+    @Test
+    public void testCreateUpdateDeleteSubmissionAsShibUserWithBadCsrfToken() throws IOException, JSONException {
+        doSamlLogin();
+
+        {
+            String url = getBaseUrl() + "data/submission";
+
+            RequestBody body = RequestBody.create("{}", JSON_API_MEDIA_TYPE);
+            Request.Builder builder = new Request.Builder();
+
+            Request request = builder.url(url).header("Accept", JSON_API_CONTENT_TYPE)
+                    .addHeader("Content-Type", JSON_API_CONTENT_TYPE)
+                    .addHeader("X-XSRF-TOKEN", "badtoken")
+                    .post(body).build();
+
+            Response response = client.newCall(request).execute();
+
+            check(response, 403);
+        }
+
+        {
+            String url = getBaseUrl() + "data/submission/1";
+            RequestBody body = RequestBody.create("{}", JSON_API_MEDIA_TYPE);
+            Request.Builder builder = new Request.Builder();
+
+            Request request = builder.url(url).header("Accept", JSON_API_CONTENT_TYPE)
+                    .addHeader("Content-Type", JSON_API_CONTENT_TYPE)
+                    .addHeader("X-XSRF-TOKEN", "badtoken")
+                    .patch(body).build();
+
+            Response response = client.newCall(request).execute();
+
+            check(response, 403);
+        }
+
+        {
+            String url = getBaseUrl() + "data/submission/1";
+            Request.Builder builder = new Request.Builder();
+
+            Request request = builder.url(url).header("Accept", JSON_API_CONTENT_TYPE)
+                    .addHeader("X-XSRF-TOKEN", "")
+                    .delete().build();
+
+            Response response = client.newCall(request).execute();
+
+            check(response, 403);
         }
     }
 
@@ -251,7 +305,9 @@ public class AccessControlTest extends SamlIntegrationTest {
             Request.Builder builder = new Request.Builder();
 
             Request request = builder.url(url).header("Accept", JSON_API_CONTENT_TYPE)
-                    .addHeader("Content-Type", JSON_API_CONTENT_TYPE).post(body).build();
+                    .addHeader("Content-Type", JSON_API_CONTENT_TYPE)
+                    .addHeader("X-XSRF-TOKEN", getCsrfToken())
+                    .post(body).build();
 
             Response response = client.newCall(request).execute();
 
@@ -266,7 +322,9 @@ public class AccessControlTest extends SamlIntegrationTest {
             Request.Builder builder = new Request.Builder();
 
             Request request = builder.url(url).header("Accept", JSON_API_CONTENT_TYPE)
-                    .addHeader("Content-Type", JSON_API_CONTENT_TYPE).patch(body).build();
+                    .addHeader("Content-Type", JSON_API_CONTENT_TYPE)
+                    .addHeader("X-XSRF-TOKEN", getCsrfToken())
+                    .patch(body).build();
 
             Response response = client.newCall(request).execute();
 
@@ -277,7 +335,9 @@ public class AccessControlTest extends SamlIntegrationTest {
             String url = getBaseUrl() + "data/publication/" + get_id(pub);
             Request.Builder builder = new Request.Builder();
 
-            Request request = builder.url(url).header("Accept", JSON_API_CONTENT_TYPE).delete().build();
+            Request request = builder.url(url).header("Accept", JSON_API_CONTENT_TYPE)
+                    .addHeader("X-XSRF-TOKEN", getCsrfToken())
+                    .delete().build();
 
             Response response = client.newCall(request).execute();
 
@@ -314,7 +374,9 @@ public class AccessControlTest extends SamlIntegrationTest {
             Request.Builder builder = new Request.Builder();
 
             Request request = builder.url(url).header("Accept", JSON_API_CONTENT_TYPE)
-                    .addHeader("Content-Type", JSON_API_CONTENT_TYPE).post(body).build();
+                    .addHeader("Content-Type", JSON_API_CONTENT_TYPE)
+                    .addHeader("X-XSRF-TOKEN", getCsrfToken())
+                    .post(body).build();
 
             Response response = client.newCall(request).execute();
 
@@ -329,7 +391,9 @@ public class AccessControlTest extends SamlIntegrationTest {
             Request.Builder builder = new Request.Builder();
 
             Request request = builder.url(url).header("Accept", JSON_API_CONTENT_TYPE)
-                    .addHeader("Content-Type", JSON_API_CONTENT_TYPE).patch(body).build();
+                    .addHeader("Content-Type", JSON_API_CONTENT_TYPE)
+                    .addHeader("X-XSRF-TOKEN", getCsrfToken())
+                    .patch(body).build();
 
             Response response = client.newCall(request).execute();
 
@@ -340,7 +404,9 @@ public class AccessControlTest extends SamlIntegrationTest {
             String url = getBaseUrl() + "data/file/" + get_id(file);
             Request.Builder builder = new Request.Builder();
 
-            Request request = builder.url(url).header("Accept", JSON_API_CONTENT_TYPE).delete().build();
+            Request request = builder.url(url).header("Accept", JSON_API_CONTENT_TYPE)
+                    .addHeader("X-XSRF-TOKEN", getCsrfToken())
+                    .delete().build();
 
             Response response = client.newCall(request).execute();
 
@@ -351,7 +417,7 @@ public class AccessControlTest extends SamlIntegrationTest {
     @Test
     public void testCreateUpdateDeleteEventAsShibUserOwningSubmission() throws IOException, JSONException {
         // File is associated with a submission associated with submitter
-        // Shib user can create file, update the file, but not delete it.
+        // Shib user can create event pointing to submission they own, but not update or delete it
 
         User submitter = doSamlLogin();
 
@@ -376,7 +442,8 @@ public class AccessControlTest extends SamlIntegrationTest {
             RequestBody body = RequestBody.create(event.toString(), JSON_API_MEDIA_TYPE);
             Request.Builder builder = new Request.Builder();
             Request request = builder.url(url).header("Accept", JSON_API_CONTENT_TYPE)
-                    .addHeader("Content-Type", JSON_API_CONTENT_TYPE).post(body).build();
+                    .addHeader("Content-Type", JSON_API_CONTENT_TYPE).addHeader("X-XSRF-TOKEN", getCsrfToken())
+                    .post(body).build();
 
             Response response = client.newCall(request).execute();
 
@@ -504,8 +571,6 @@ public class AccessControlTest extends SamlIntegrationTest {
 
     @Test
     public void testCreateUpdateDeleteGrantAsBackend() throws IOException, JSONException {
-        String credentials = Credentials.basic(BACKEND_USER, BACKEND_PASSWORD);
-
         JSONObject grant = pass_object("grant");
         set_attribute(grant, "projectName", "backend test");
 
@@ -515,8 +580,9 @@ public class AccessControlTest extends SamlIntegrationTest {
 
             RequestBody body = RequestBody.create(grant.toString(), JSON_API_MEDIA_TYPE);
             Request request = new Request.Builder().url(url).header("Accept", JSON_API_CONTENT_TYPE)
-                    .addHeader("Content-Type", JSON_API_CONTENT_TYPE).header("Authorization", credentials).post(body)
-                    .build();
+                    .addHeader("Content-Type", JSON_API_CONTENT_TYPE).header("Authorization", BACKEND_CREDENTIALS)
+                    .addHeader("X-XSRF-TOKEN", getCsrfToken())
+                    .post(body).build();
 
             Response response = client.newCall(request).execute();
 
@@ -530,7 +596,9 @@ public class AccessControlTest extends SamlIntegrationTest {
             String url = getBaseUrl() + "data/grant/" + get_id(grant);
             RequestBody body = RequestBody.create(grant.toString(), JSON_API_MEDIA_TYPE);
             Request request = new Request.Builder().url(url).header("Accept", JSON_API_CONTENT_TYPE)
-                    .addHeader("Content-Type", JSON_API_CONTENT_TYPE).header("Authorization", credentials).patch(body)
+                    .addHeader("Content-Type", JSON_API_CONTENT_TYPE).header("Authorization", BACKEND_CREDENTIALS)
+                    .addHeader("X-XSRF-TOKEN", getCsrfToken())
+                    .patch(body)
                     .build();
 
             Response response = client.newCall(request).execute();
@@ -542,7 +610,9 @@ public class AccessControlTest extends SamlIntegrationTest {
         {
             String url = getBaseUrl() + "data/grant/" + get_id(grant);
             Request request = new Request.Builder().url(url).header("Accept", JSON_API_CONTENT_TYPE)
-                    .header("Authorization", credentials).delete().build();
+                    .header("Authorization", BACKEND_CREDENTIALS)
+                    .addHeader("X-XSRF-TOKEN", getCsrfToken())
+                    .delete().build();
 
             Response response = client.newCall(request).execute();
 
@@ -623,7 +693,6 @@ public class AccessControlTest extends SamlIntegrationTest {
 
         assertNotNull(ses);
 
-        // Logout
         {
             String url = getBaseUrl() + "logout";
 

--- a/pass-core-main/src/test/java/org/eclipse/pass/main/security/AccessControlTest.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/main/security/AccessControlTest.java
@@ -18,9 +18,11 @@ package org.eclipse.pass.main.security;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
+import java.util.List;
 
 import okhttp3.Cookie;
 import okhttp3.Credentials;
@@ -119,7 +121,7 @@ public class AccessControlTest extends SamlIntegrationTest {
         String url = getBaseUrl() + "data/grant";
 
         Request request = new Request.Builder().url(url).header("Accept", JSON_API_CONTENT_TYPE)
-                .addHeader("Content-Type", JSON_API_CONTENT_TYPE).get().build();
+                .header("Content-Type", JSON_API_CONTENT_TYPE).get().build();
 
         Response response = client.newCall(request).execute();
 
@@ -131,7 +133,7 @@ public class AccessControlTest extends SamlIntegrationTest {
         String url = getBaseUrl() + "data/grant";
 
         Request request = new Request.Builder().url(url).header("Accept", JSON_API_CONTENT_TYPE)
-                .addHeader("Content-Type", JSON_API_CONTENT_TYPE)
+                .header("Content-Type", JSON_API_CONTENT_TYPE)
                 .header("Authorization", BACKEND_CREDENTIALS).get().build();
 
         Response response = client.newCall(request).execute();
@@ -146,7 +148,7 @@ public class AccessControlTest extends SamlIntegrationTest {
         String credentials = Credentials.basic("baduser", "badpassword");
 
         Request request = new Request.Builder().url(url).header("Accept", JSON_API_CONTENT_TYPE)
-                .addHeader("Content-Type", JSON_API_CONTENT_TYPE).header("Authorization", credentials).get().build();
+                .header("Content-Type", JSON_API_CONTENT_TYPE).header("Authorization", credentials).get().build();
 
         Response response = client.newCall(request).execute();
 
@@ -161,7 +163,7 @@ public class AccessControlTest extends SamlIntegrationTest {
 
         Request.Builder builder = new Request.Builder();
         Request request = builder.url(url).header("Accept", JSON_API_CONTENT_TYPE)
-                .addHeader("Content-Type", JSON_API_CONTENT_TYPE).get().build();
+                .header("Content-Type", JSON_API_CONTENT_TYPE).get().build();
 
         Response response = client.newCall(request).execute();
 
@@ -180,7 +182,7 @@ public class AccessControlTest extends SamlIntegrationTest {
         Request.Builder builder = new Request.Builder();
 
         Request request = builder.url(url).header("Accept", JSON_API_CONTENT_TYPE)
-                .addHeader("Content-Type", JSON_API_CONTENT_TYPE).post(body).build();
+                .header("Content-Type", JSON_API_CONTENT_TYPE).post(body).build();
 
         Response response = client.newCall(request).execute();
 
@@ -202,8 +204,8 @@ public class AccessControlTest extends SamlIntegrationTest {
             Request.Builder builder = new Request.Builder();
 
             Request request = builder.url(url).header("Accept", JSON_API_CONTENT_TYPE)
-                    .addHeader("Content-Type", JSON_API_CONTENT_TYPE)
-                    .addHeader("X-XSRF-TOKEN", getCsrfToken())
+                    .header("Content-Type", JSON_API_CONTENT_TYPE)
+                    .header("X-XSRF-TOKEN", getCsrfToken())
                     .post(body).build();
 
             Response response = client.newCall(request).execute();
@@ -219,8 +221,8 @@ public class AccessControlTest extends SamlIntegrationTest {
             Request.Builder builder = new Request.Builder();
 
             Request request = builder.url(url).header("Accept", JSON_API_CONTENT_TYPE)
-                    .addHeader("Content-Type", JSON_API_CONTENT_TYPE)
-                    .addHeader("X-XSRF-TOKEN", getCsrfToken())
+                    .header("Content-Type", JSON_API_CONTENT_TYPE)
+                    .header("X-XSRF-TOKEN", getCsrfToken())
                     .patch(body).build();
 
             Response response = client.newCall(request).execute();
@@ -233,7 +235,7 @@ public class AccessControlTest extends SamlIntegrationTest {
             Request.Builder builder = new Request.Builder();
 
             Request request = builder.url(url).header("Accept", JSON_API_CONTENT_TYPE)
-                    .addHeader("X-XSRF-TOKEN", getCsrfToken())
+                    .header("X-XSRF-TOKEN", getCsrfToken())
                     .delete().build();
 
             Response response = client.newCall(request).execute();
@@ -253,8 +255,8 @@ public class AccessControlTest extends SamlIntegrationTest {
             Request.Builder builder = new Request.Builder();
 
             Request request = builder.url(url).header("Accept", JSON_API_CONTENT_TYPE)
-                    .addHeader("Content-Type", JSON_API_CONTENT_TYPE)
-                    .addHeader("X-XSRF-TOKEN", "badtoken")
+                    .header("Content-Type", JSON_API_CONTENT_TYPE)
+                    .header("X-XSRF-TOKEN", "badtoken")
                     .post(body).build();
 
             Response response = client.newCall(request).execute();
@@ -268,8 +270,8 @@ public class AccessControlTest extends SamlIntegrationTest {
             Request.Builder builder = new Request.Builder();
 
             Request request = builder.url(url).header("Accept", JSON_API_CONTENT_TYPE)
-                    .addHeader("Content-Type", JSON_API_CONTENT_TYPE)
-                    .addHeader("X-XSRF-TOKEN", "badtoken")
+                    .header("Content-Type", JSON_API_CONTENT_TYPE)
+                    .header("X-XSRF-TOKEN", "badtoken")
                     .patch(body).build();
 
             Response response = client.newCall(request).execute();
@@ -282,7 +284,7 @@ public class AccessControlTest extends SamlIntegrationTest {
             Request.Builder builder = new Request.Builder();
 
             Request request = builder.url(url).header("Accept", JSON_API_CONTENT_TYPE)
-                    .addHeader("X-XSRF-TOKEN", "")
+                    .header("X-XSRF-TOKEN", "")
                     .delete().build();
 
             Response response = client.newCall(request).execute();
@@ -305,8 +307,8 @@ public class AccessControlTest extends SamlIntegrationTest {
             Request.Builder builder = new Request.Builder();
 
             Request request = builder.url(url).header("Accept", JSON_API_CONTENT_TYPE)
-                    .addHeader("Content-Type", JSON_API_CONTENT_TYPE)
-                    .addHeader("X-XSRF-TOKEN", getCsrfToken())
+                    .header("Content-Type", JSON_API_CONTENT_TYPE)
+                    .header("X-XSRF-TOKEN", getCsrfToken())
                     .post(body).build();
 
             Response response = client.newCall(request).execute();
@@ -322,8 +324,8 @@ public class AccessControlTest extends SamlIntegrationTest {
             Request.Builder builder = new Request.Builder();
 
             Request request = builder.url(url).header("Accept", JSON_API_CONTENT_TYPE)
-                    .addHeader("Content-Type", JSON_API_CONTENT_TYPE)
-                    .addHeader("X-XSRF-TOKEN", getCsrfToken())
+                    .header("Content-Type", JSON_API_CONTENT_TYPE)
+                    .header("X-XSRF-TOKEN", getCsrfToken())
                     .patch(body).build();
 
             Response response = client.newCall(request).execute();
@@ -336,7 +338,7 @@ public class AccessControlTest extends SamlIntegrationTest {
             Request.Builder builder = new Request.Builder();
 
             Request request = builder.url(url).header("Accept", JSON_API_CONTENT_TYPE)
-                    .addHeader("X-XSRF-TOKEN", getCsrfToken())
+                    .header("X-XSRF-TOKEN", getCsrfToken())
                     .delete().build();
 
             Response response = client.newCall(request).execute();
@@ -374,8 +376,8 @@ public class AccessControlTest extends SamlIntegrationTest {
             Request.Builder builder = new Request.Builder();
 
             Request request = builder.url(url).header("Accept", JSON_API_CONTENT_TYPE)
-                    .addHeader("Content-Type", JSON_API_CONTENT_TYPE)
-                    .addHeader("X-XSRF-TOKEN", getCsrfToken())
+                    .header("Content-Type", JSON_API_CONTENT_TYPE)
+                    .header("X-XSRF-TOKEN", getCsrfToken())
                     .post(body).build();
 
             Response response = client.newCall(request).execute();
@@ -391,8 +393,8 @@ public class AccessControlTest extends SamlIntegrationTest {
             Request.Builder builder = new Request.Builder();
 
             Request request = builder.url(url).header("Accept", JSON_API_CONTENT_TYPE)
-                    .addHeader("Content-Type", JSON_API_CONTENT_TYPE)
-                    .addHeader("X-XSRF-TOKEN", getCsrfToken())
+                    .header("Content-Type", JSON_API_CONTENT_TYPE)
+                    .header("X-XSRF-TOKEN", getCsrfToken())
                     .patch(body).build();
 
             Response response = client.newCall(request).execute();
@@ -405,7 +407,7 @@ public class AccessControlTest extends SamlIntegrationTest {
             Request.Builder builder = new Request.Builder();
 
             Request request = builder.url(url).header("Accept", JSON_API_CONTENT_TYPE)
-                    .addHeader("X-XSRF-TOKEN", getCsrfToken())
+                    .header("X-XSRF-TOKEN", getCsrfToken())
                     .delete().build();
 
             Response response = client.newCall(request).execute();
@@ -442,7 +444,7 @@ public class AccessControlTest extends SamlIntegrationTest {
             RequestBody body = RequestBody.create(event.toString(), JSON_API_MEDIA_TYPE);
             Request.Builder builder = new Request.Builder();
             Request request = builder.url(url).header("Accept", JSON_API_CONTENT_TYPE)
-                    .addHeader("Content-Type", JSON_API_CONTENT_TYPE).addHeader("X-XSRF-TOKEN", getCsrfToken())
+                    .header("Content-Type", JSON_API_CONTENT_TYPE).header("X-XSRF-TOKEN", getCsrfToken())
                     .post(body).build();
 
             Response response = client.newCall(request).execute();
@@ -457,7 +459,7 @@ public class AccessControlTest extends SamlIntegrationTest {
             RequestBody body = RequestBody.create(event.toString(), JSON_API_MEDIA_TYPE);
             Request.Builder builder = new Request.Builder();
             Request request = builder.url(url).header("Accept", JSON_API_CONTENT_TYPE)
-                    .addHeader("Content-Type", JSON_API_CONTENT_TYPE).patch(body).build();
+                    .header("Content-Type", JSON_API_CONTENT_TYPE).patch(body).build();
 
             Response response = client.newCall(request).execute();
 
@@ -488,7 +490,7 @@ public class AccessControlTest extends SamlIntegrationTest {
         RequestBody body = RequestBody.create(file.toString(), JSON_API_MEDIA_TYPE);
         Request.Builder builder = new Request.Builder();
         Request request = builder.url(url).header("Accept", JSON_API_CONTENT_TYPE)
-                .addHeader("Content-Type", JSON_API_CONTENT_TYPE).post(body).build();
+                .header("Content-Type", JSON_API_CONTENT_TYPE).post(body).build();
 
         Response response = client.newCall(request).execute();
 
@@ -509,7 +511,7 @@ public class AccessControlTest extends SamlIntegrationTest {
         Request.Builder builder = new Request.Builder();
 
         Request request = builder.url(url).header("Accept", JSON_API_CONTENT_TYPE)
-                .addHeader("Content-Type", JSON_API_CONTENT_TYPE).post(body).build();
+                .header("Content-Type", JSON_API_CONTENT_TYPE).post(body).build();
 
         Response response = client.newCall(request).execute();
 
@@ -538,7 +540,7 @@ public class AccessControlTest extends SamlIntegrationTest {
         Request.Builder builder = new Request.Builder();
 
         Request request = builder.url(url).header("Accept", JSON_API_CONTENT_TYPE)
-                .addHeader("Content-Type", JSON_API_CONTENT_TYPE).patch(body).build();
+                .header("Content-Type", JSON_API_CONTENT_TYPE).patch(body).build();
 
         Response response = client.newCall(request).execute();
 
@@ -580,8 +582,8 @@ public class AccessControlTest extends SamlIntegrationTest {
 
             RequestBody body = RequestBody.create(grant.toString(), JSON_API_MEDIA_TYPE);
             Request request = new Request.Builder().url(url).header("Accept", JSON_API_CONTENT_TYPE)
-                    .addHeader("Content-Type", JSON_API_CONTENT_TYPE).header("Authorization", BACKEND_CREDENTIALS)
-                    .addHeader("X-XSRF-TOKEN", getCsrfToken())
+                    .header("Content-Type", JSON_API_CONTENT_TYPE).header("Authorization", BACKEND_CREDENTIALS)
+                    .header("X-XSRF-TOKEN", getCsrfToken())
                     .post(body).build();
 
             Response response = client.newCall(request).execute();
@@ -596,8 +598,8 @@ public class AccessControlTest extends SamlIntegrationTest {
             String url = getBaseUrl() + "data/grant/" + get_id(grant);
             RequestBody body = RequestBody.create(grant.toString(), JSON_API_MEDIA_TYPE);
             Request request = new Request.Builder().url(url).header("Accept", JSON_API_CONTENT_TYPE)
-                    .addHeader("Content-Type", JSON_API_CONTENT_TYPE).header("Authorization", BACKEND_CREDENTIALS)
-                    .addHeader("X-XSRF-TOKEN", getCsrfToken())
+                    .header("Content-Type", JSON_API_CONTENT_TYPE).header("Authorization", BACKEND_CREDENTIALS)
+                    .header("X-XSRF-TOKEN", getCsrfToken())
                     .patch(body)
                     .build();
 
@@ -611,12 +613,82 @@ public class AccessControlTest extends SamlIntegrationTest {
             String url = getBaseUrl() + "data/grant/" + get_id(grant);
             Request request = new Request.Builder().url(url).header("Accept", JSON_API_CONTENT_TYPE)
                     .header("Authorization", BACKEND_CREDENTIALS)
-                    .addHeader("X-XSRF-TOKEN", getCsrfToken())
+                    .header("X-XSRF-TOKEN", getCsrfToken())
                     .delete().build();
 
             Response response = client.newCall(request).execute();
 
             check(response, 204);
+        }
+    }
+
+    @Test
+    public void testChooseCsrfTokenAsBackend() throws IOException, JSONException {
+        JSONObject grant = pass_object("grant");
+        set_attribute(grant, "projectName", "backend test");
+
+        HttpUrl base_url = HttpUrl.get(getBaseUrl());
+        String url = getBaseUrl() + "data/grant";
+
+        // Save our own CSRF token
+        assertNull(get_cookie("XSRF-TOKEN"));
+        client.cookieJar().saveFromResponse(base_url,
+                List.of(Cookie.parse(base_url, "XSRF-TOKEN=moo")));
+        assertNotNull(get_cookie("XSRF-TOKEN"));
+
+        // Create a grant with CSRF token
+        {
+            RequestBody body = RequestBody.create(grant.toString(), JSON_API_MEDIA_TYPE);
+            Request request = new Request.Builder().url(url).header("Accept", JSON_API_CONTENT_TYPE)
+                    .header("Content-Type", JSON_API_CONTENT_TYPE).header("Authorization", BACKEND_CREDENTIALS)
+                    .header("X-XSRF-TOKEN", "moo").post(body).build();
+
+            Response response = client.newCall(request).execute();
+
+            check(response, 201);
+        }
+
+        // Fails if header does not match token
+        {
+            RequestBody body = RequestBody.create(grant.toString(), JSON_API_MEDIA_TYPE);
+            Request request = new Request.Builder().url(url).header("Accept", JSON_API_CONTENT_TYPE)
+                    .header("Content-Type", JSON_API_CONTENT_TYPE).header("Authorization", BACKEND_CREDENTIALS)
+                    .header("X-XSRF-TOKEN", "badmoo").post(body).build();
+
+            Response response = client.newCall(request).execute();
+
+            check(response, 403);
+        }
+    }
+
+    @Test
+    public void testChooseCsrfTokenAsShibUser() throws IOException, JSONException {
+        HttpUrl base_url = HttpUrl.get(getBaseUrl());
+
+        doSamlLogin();
+
+        JSONObject grant = pass_object("grant");
+        set_attribute(grant, "projectName", "backend test");
+
+        // Save our own CSRF token
+        client.cookieJar().saveFromResponse(base_url,
+                List.of(Cookie.parse(base_url, "XSRF-TOKEN=moo")));
+
+        assertEquals("moo", getCsrfToken());
+
+        // Create a grant with a made up CSRF token
+        {
+            String url = getBaseUrl() + "data/grant";
+
+            RequestBody body = RequestBody.create(grant.toString(), JSON_API_MEDIA_TYPE);
+            Request request = new Request.Builder().url(url).header("Accept", JSON_API_CONTENT_TYPE)
+                    .header("Content-Type", JSON_API_CONTENT_TYPE).header("X-XSRF-TOKEN", getCsrfToken())
+                    .post(body).build();
+
+            Response response = client.newCall(request).execute();
+
+            // Fails because CSRF token tied to session
+            check(response, 403);
         }
     }
 

--- a/pass-core-main/src/test/java/org/eclipse/pass/metadataschema/MetadataSchemaServiceTest.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/metadataschema/MetadataSchemaServiceTest.java
@@ -18,7 +18,7 @@ import okhttp3.Credentials;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
-import org.eclipse.pass.main.IntegrationTest;
+import org.eclipse.pass.main.SimpleIntegrationTest;
 import org.eclipse.pass.object.PassClient;
 import org.eclipse.pass.object.model.IntegrationType;
 import org.eclipse.pass.object.model.Repository;
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 
-public class MetadataSchemaServiceTest extends IntegrationTest {
+public class MetadataSchemaServiceTest extends SimpleIntegrationTest {
     private final String credentials = Credentials.basic(BACKEND_USER, BACKEND_PASSWORD);
     private final OkHttpClient httpClient = new OkHttpClient();
     private Long repo1Id;

--- a/pass-core-main/src/test/java/org/eclipse/pass/object/ElidePassClientTest.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/object/ElidePassClientTest.java
@@ -30,7 +30,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import com.yahoo.elide.RefreshableElide;
-import org.eclipse.pass.main.IntegrationTest;
+import org.eclipse.pass.main.SimpleIntegrationTest;
 import org.eclipse.pass.object.model.AggregatedDepositStatus;
 import org.eclipse.pass.object.model.Deposit;
 import org.eclipse.pass.object.model.DepositStatus;
@@ -55,7 +55,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 /**
  * Tests must be written such that they can run in any order and handle objects already existing.
  */
-public class ElidePassClientTest extends IntegrationTest {
+public class ElidePassClientTest extends SimpleIntegrationTest {
     protected PassClient client;
 
     @Autowired

--- a/pass-core-main/src/test/java/org/eclipse/pass/policy/PolicyServiceTest.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/policy/PolicyServiceTest.java
@@ -146,8 +146,10 @@ public class PolicyServiceTest extends SamlIntegrationTest {
 
         try (Response okHttpResponse = call.execute()) {
             assertEquals(200, okHttpResponse.code());
-            assert okHttpResponse.body() != null;
-            JSONArray result = new JSONArray(okHttpResponse.body().string());
+            String body = okHttpResponse.body().string();
+
+            assert body != null;
+            JSONArray result = new JSONArray(body);
             assertEquals(3, result.length());
 
             for (int i = 0; i < result.length(); i++) {
@@ -185,8 +187,9 @@ public class PolicyServiceTest extends SamlIntegrationTest {
 
         try (Response okHttpResponse = call.execute()) {
             assertEquals(200, okHttpResponse.code());
-            assert okHttpResponse.body() != null;
-            JSONObject result = new JSONObject(okHttpResponse.body().string());
+            String body = okHttpResponse.body().string();
+            assert body != null;
+            JSONObject result = new JSONObject(body);
             assertEquals(2, result.length());
 
             //the IR - we recommend this by calling it selected
@@ -257,8 +260,9 @@ public class PolicyServiceTest extends SamlIntegrationTest {
 
         try (Response okHttpResponse = call.execute()) {
             assertEquals(200, okHttpResponse.code());
-            assert okHttpResponse.body() != null;
-            JSONArray result = new JSONArray(okHttpResponse.body().string());
+            String body = okHttpResponse.body().string();
+            assert body != null;
+            JSONArray result = new JSONArray(body);
             assertEquals(1, result.length());
         }
 
@@ -274,8 +278,9 @@ public class PolicyServiceTest extends SamlIntegrationTest {
         // Since effective policies is empty, no repositories will be returned
         try (Response okHttpResponse = call1.execute()) {
             assertEquals(200, okHttpResponse.code());
-            assert okHttpResponse.body() != null;
-            JSONObject result = new JSONObject(okHttpResponse.body().string());
+            String body = okHttpResponse.body().string();
+            assert body != null;
+            JSONObject result = new JSONObject(body);
 
             JSONArray optional = (JSONArray) result.get("optional");
             assertEquals(0, optional.length());


### PR DESCRIPTION
Turns on CSRF protection using cookies and headers. Responses from the API will set a cookie XSRF-TOKEN and non-GET requests from the client must set the header X-XSRF-TOKEN with the value of the cookie. GET requests to the /doi service are also protected because they have side effects.

In addition the integration tests have been refactored to handle the CSRF token and do a little more testing.

By default CSRF protection requires a POST to to /logout. This is disabled for now because the a POST to that endpoint with the header set returns a login form with a CSRF token hidden in the form. Submitting that form does do the logout. The format of the token in the in the form is different from the cookie. In addition doing a POST to /logout will initiate the SAML logout process. The complications don't seem to make protecting /logout worthwhile at the moment.

Clients can user any CSRF token they want. The cookie and header just must be consistent. 

Required prs:
  *  https://github.com/eclipse-pass/pass-support/pull/116
  * https://github.com/eclipse-pass/pass-ui/pull/1276
  * https://github.com/eclipse-pass/pass-docker/pull/375

Acceptance tests pass, but require the updated pass-core and pass-support images running in the updated pass-docker.
