### PR TITLE
Change repackage configuration

### DIFF
--- a/pass-core-main/Dockerfile
+++ b/pass-core-main/Dockerfile
@@ -2,7 +2,7 @@ FROM eclipse-temurin:17.0.8_7-jre-jammy
 
 WORKDIR /app
 
-COPY target/pass-core-main.jar .
+COPY target/pass-core-main-*-exec.jar pass-core-main.jar
 COPY entrypoint.sh .
 
 RUN apt update \

--- a/pass-core-main/pom.xml
+++ b/pass-core-main/pom.xml
@@ -230,6 +230,20 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${spring-boot-maven-plugin.version}</version>
+        <executions>
+          <execution>
+            <id>repackage</id>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+            <configuration>
+              <mainClass>org.eclipse.pass.main.Main</mainClass>
+              <classifier>exec</classifier>
+              <attach>false</attach>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -154,26 +154,6 @@
   </dependencyManagement>
 
   <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.springframework.boot</groupId>
-          <artifactId>spring-boot-maven-plugin</artifactId>
-          <version>${spring-boot-maven-plugin.version}</version>
-          <configuration>
-            <mainClass>org.eclipse.pass.main.Main</mainClass>
-            <finalName>pass-core-main</finalName>
-          </configuration>
-          <executions>
-            <execution>
-              <goals>
-                <goal>repackage</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
-      </plugins>
-    </pluginManagement>
 
     <plugins>
       <plugin>


### PR DESCRIPTION
This PR makes the following changes to the `repackage` configuration:

- Remove the `finalName` configuration.  It is read-only and should not be changed any longer: https://github.com/spring-projects/spring-boot/issues/16202#issuecomment-500208885
- Set `attach` as false so the repackaged jar file is not deployed.  If this works like I think it will, it may speed up the deploy goal since the repackaged jar file will not be deployed to sonatype snapshot/release.
- Removed `pluginManagement` from pass-core root pom since pass-core-main is the only module using repackage.