### PR TITLE
Fix handling of SAML optional attributes

### DIFF
--- a/pass-core-main/src/main/java/org/eclipse/pass/main/security/PassAuthenticationFilter.java
+++ b/pass-core-main/src/main/java/org/eclipse/pass/main/security/PassAuthenticationFilter.java
@@ -141,7 +141,7 @@ public class PassAuthenticationFilter extends OncePerRequestFilter {
             });
         }
 
-        User user = parse_user(principal.getAttributes());
+        User user = parseUser(principal.getAttributes());
         create_or_update_pass_user(user);
 
         return new PassAuthentication(user);
@@ -229,10 +229,10 @@ public class PassAuthenticationFilter extends OncePerRequestFilter {
     }
 
     /**
-     * @param attributes
-     * @return User representing the information in the request.
+     * @param attributes of an authenticating user
+     * @return User representing the attributes
      */
-    private User parse_user(Map<String, List<Object>> attributes) {
+    User parseUser(Map<String, List<Object>> attributes) {
         User user = new User();
 
         String display_name = get(attributes, Attribute.DISPLAY_NAME, true);
@@ -293,13 +293,9 @@ public class PassAuthenticationFilter extends OncePerRequestFilter {
 
         List<Object> values = attributes.get(key);
 
-        if (values == null || values.size() == 0 && required) {
-            throw new BadCredentialsException("Missing attribute: " + attr + "[" + key + "]");
-        }
-
         String value = null;
 
-        if (values.get(0) != null) {
+        if (values != null && values.size() > 0 && values.get(0) != null) {
             value = values.get(0).toString().trim();
         }
 

--- a/pass-core-main/src/test/java/org/eclipse/pass/main/security/PassAuthenticationFilterTest.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/main/security/PassAuthenticationFilterTest.java
@@ -5,16 +5,22 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 
 import org.eclipse.pass.main.SamlIntegrationTest;
 import org.eclipse.pass.object.PassClient;
 import org.eclipse.pass.object.model.User;
 import org.eclipse.pass.object.model.UserRole;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 public class PassAuthenticationFilterTest extends SamlIntegrationTest {
+    @Autowired
+    private PassAuthenticationFilter passAuthFilter;
+
     @Test
     public void testLoggedInUser() throws IOException {
         User submitter = doSamlLogin();
@@ -64,5 +70,62 @@ public class PassAuthenticationFilterTest extends SamlIntegrationTest {
         // User should have been reset.
         assertNotEquals(updated, result);
         assertEquals(submitter, result);
+    }
+
+    @Test
+    public void testParseUser() {
+        Map<String, List<Object>> attributes = new HashMap<>();
+
+        attributes.put("urn:oid:2.16.840.1.113730.3.1.241", List.of("Thomas L. Submitter"));
+        attributes.put("urn:oid:1.3.6.1.4.1.5923.1.1.1.9", List.of("FACULTY@johnshopkins.edu"));
+        attributes.put("urn:oid:0.9.2342.19200300.100.1.3", List.of("tom987654321@jhu.edu"));
+        attributes.put("urn:oid:1.3.6.1.4.1.5923.1.1.1.6", List.of("thomassubmitter987654321@johnshopkins.edu"));
+        attributes.put("urn:oid:2.5.4.42", List.of("Tom"));
+        attributes.put("urn:oid:2.5.4.4", List.of("Submitter"));
+        attributes.put("urn:oid:2.16.840.1.113730.3.1.3", List.of("987654321"));
+        attributes.put("urn:oid:1.3.6.1.4.1.5923.1.1.1.13", List.of("tls987654321@johnshopkins.edu"));
+
+        User expected = new User();
+        expected.setDisplayName("Thomas L. Submitter");
+        expected.setEmail("tom987654321@jhu.edu");
+        expected.setAffiliation(new HashSet<>(List.of("FACULTY@johnshopkins.edu", "johnshopkins.edu")));
+        expected.setFirstName("Tom");
+        expected.setLastName("Submitter");
+        expected.setLocatorIds(List.of("johnshopkins.edu:unique-id:tls987654321",
+                "johnshopkins.edu:eppn:thomassubmitter987654321",
+                "johnshopkins.edu:employeeid:987654321"));
+        expected.setUsername("thomassubmitter987654321@johnshopkins.edu");
+        expected.setRoles(List.of(UserRole.SUBMITTER));
+
+        User user = passAuthFilter.parseUser(attributes);
+
+        assertEquals(expected, user);
+    }
+
+    @Test
+    public void testParseUserMissingEmployeeIdAndAffiliation() {
+        Map<String, List<Object>> attributes = new HashMap<>();
+
+        attributes.put("urn:oid:2.16.840.1.113730.3.1.241", List.of("Thomas L. Submitter"));
+        attributes.put("urn:oid:0.9.2342.19200300.100.1.3", List.of("tom987654321@jhu.edu"));
+        attributes.put("urn:oid:1.3.6.1.4.1.5923.1.1.1.6", List.of("thomassubmitter987654321@johnshopkins.edu"));
+        attributes.put("urn:oid:2.5.4.42", List.of("Tom"));
+        attributes.put("urn:oid:2.5.4.4", List.of("Submitter"));
+        attributes.put("urn:oid:1.3.6.1.4.1.5923.1.1.1.13", List.of("tls987654321@johnshopkins.edu"));
+
+        User expected = new User();
+        expected.setDisplayName("Thomas L. Submitter");
+        expected.setEmail("tom987654321@jhu.edu");
+        expected.setAffiliation(new HashSet<>(List.of("johnshopkins.edu")));
+        expected.setFirstName("Tom");
+        expected.setLastName("Submitter");
+        expected.setLocatorIds(List.of("johnshopkins.edu:unique-id:tls987654321",
+                "johnshopkins.edu:eppn:thomassubmitter987654321"));
+        expected.setUsername("thomassubmitter987654321@johnshopkins.edu");
+        expected.setRoles(List.of(UserRole.SUBMITTER));
+
+        User user = passAuthFilter.parseUser(attributes);
+
+        assertEquals(expected, user);
     }
 }


### PR DESCRIPTION
Some SAML attributes, employee id and affiliation, are optional. A bug was requiring them instead.