### PR TITLE
Modify DOI service to not return entries without a URL

### DIFF
--- a/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/UnpaywallDoiService.java
+++ b/pass-core-doi-service/src/main/java/org/eclipse/pass/doi/service/UnpaywallDoiService.java
@@ -16,6 +16,9 @@
  */
 package org.eclipse.pass.doi.service;
 
+import java.io.File;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.HashMap;
 import javax.json.Json;
 import javax.json.JsonArray;
@@ -57,6 +60,20 @@ public class UnpaywallDoiService extends ExternalDoiService {
         return null;
     }
 
+    private String get_filename(String url) {
+        try {
+            URI uri = new URI(url);
+
+            if (uri.getPath() == null) {
+                return null;
+            }
+
+            return new File(uri.getPath()).getName();
+        } catch (URISyntaxException e) {
+            return null;
+        }
+    }
+
     @Override
     public JsonObject processObject(JsonObject object) {
         JsonArray locations = object.getJsonArray("oa_locations");
@@ -67,13 +84,12 @@ public class UnpaywallDoiService extends ExternalDoiService {
             JsonValue urlForPdf = manuscript.getValue("/url_for_pdf");
             JsonValue isBest = manuscript.getValue("/is_best");
 
-            JsonValue filename;
             if ( urlForPdf == JsonValue.NULL ) {
-                filename = JsonValue.NULL;
-            } else {
-                String urlForPdfString = urlForPdf.toString().replaceAll("\"","");
-                filename = Json.createValue (urlForPdfString.substring(urlForPdfString.lastIndexOf('/') + 1));
+                continue;
             }
+
+            String name = get_filename(manuscript.getString("url_for_pdf"));
+            JsonValue filename = name == null ? JsonValue.NULL : Json.createValue(name);
 
             JsonValue repoInst = manuscript.getValue("/repository_institution");
 

--- a/pass-core-doi-service/src/test/java/org/eclipse/pass/doi/service/UnpaywallDoiServiceTest.java
+++ b/pass-core-doi-service/src/test/java/org/eclipse/pass/doi/service/UnpaywallDoiServiceTest.java
@@ -31,9 +31,8 @@ public class UnpaywallDoiServiceTest {
         "\"repositoryLabel\":null,\"type\":\"application/pdf\",\"source\":\"Unpaywall\"," +
         "\"name\":\"CMC.S38446\",\"isBest\":true},{\"url\":\"https://europepmc.org/articles/pmc5072460?pdf=render\"," +
         "\"repositoryLabel\":\"PubMed Central - Europe PMC\",\"type\":\"application/pdf\"," +
-        "\"source\":\"Unpaywall\",\"name\":\"pmc5072460?pdf=render\",\"isBest\":false}," +
-        "{\"url\":null,\"repositoryLabel\":null,\"type\":\"application/pdf\"," +
-        "\"source\":\"Unpaywall\",\"name\":null,\"isBest\":false}]}";
+        "\"source\":\"Unpaywall\",\"name\":\"pmc5072460\",\"isBest\":false}" +
+        "]}";
 
     @Test
     public void testProcessObject() {


### PR DESCRIPTION
This PR updates the DOI service such that entries without a URL are not returned. In addition the returned filenames are parsed from the URL in a more reliable way so that we do not return filenames like `blah.pdf?render=pdf`.