### PR TITLE
Remove stacktrace from error responses

### DIFF
--- a/pass-core-main/src/main/resources/application.yaml
+++ b/pass-core-main/src/main/resources/application.yaml
@@ -152,8 +152,6 @@ spring:
 
 server:
   port: ${PASS_CORE_PORT}
-  error:
-    include-stacktrace: always
 
 pass:
   jms:


### PR DESCRIPTION
This will fix the issue with showing the stacktrace on the Whitelabel error page for HTML clients.  

Note that the stacktrace was also being included in error responses for JSON clients.  With this PR, the stacktrace will no longer be in the error response for JSON clients as well.

The Whitelabel Error Page now looks like:

![Screenshot 2024-10-15 at 4 07 31 PM](https://github.com/user-attachments/assets/4b9f9a21-c13e-4d32-9e2d-4bd3ab0fb31a)
