### PR TITLE
Create SBOM

### DIFF
--- a/pass-core-main/pom.xml
+++ b/pass-core-main/pom.xml
@@ -246,10 +246,17 @@
               <mainClass>org.eclipse.pass.main.Main</mainClass>
               <classifier>exec</classifier>
               <attach>false</attach>
+              <includeTools>false</includeTools>
             </configuration>
           </execution>
         </executions>
       </plugin>
+
+      <plugin>
+        <groupId>org.cyclonedx</groupId>
+        <artifactId>cyclonedx-maven-plugin</artifactId>
+      </plugin>
+
     </plugins>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -25,32 +25,32 @@
     <developer>
       <name>Jim Martino</name>
       <email>jrm@jhu.edu</email>
-      <organization>The Sheridan Libraries, Johns Hopkins Univeristy</organization>
-      <organizationUrl>https://www.library.jhu.edu/</organizationUrl>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
     </developer>
     <developer>
       <name>Mark Patton</name>
       <email>mpatton@jhu.edu</email>
       <organization>The Sheridan Libraries, Johns Hopkins University</organization>
-      <organizationUrl>https://www.library.jhu.edu/</organizationUrl>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
     </developer>
     <developer>
       <name>John Abrahams</name>
       <email>jabrah20@jhu.edu</email>
       <organization>The Sheridan Libraries, Johns Hopkins University</organization>
-      <organizationUrl>https://www.library.jhu.edu/</organizationUrl>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
     </developer>
     <developer>
       <name>Tim Sanders</name>
       <email>tsande16@jhu.edu</email>
       <organization>The Sheridan Libraries, Johns Hopkins University</organization>
-      <organizationUrl>https://www.library.jhu.edu/</organizationUrl>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
     </developer>
     <developer>
       <name>Russ Poetker</name>
       <email>rpoetke1@jhu.edu</email>
       <organization>The Sheridan Libraries, Johns Hopkins University</organization>
-      <organizationUrl>https://www.library.jhu.edu/</organizationUrl>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
     </developer>
   </developers>
 


### PR DESCRIPTION
This PR adds configuration so an SBOM is created in `pass-core-main`. The SBOMs is created as part of the maven build lifecycle. The SBOM is saved in `pass-core-main/target/classes/META-INF/sbom/application.cdx.json`.

I confirmed that all the jar files in the pass-core-main uber jar are listed in the SBOM.

**Note that the SBOM file will also publish to maven central/snapshots with associated artifacts.**

I used the [sbom-utility](https://github.com/CycloneDX/sbom-utility) to validate each SBOM.  There are two dependencies that have sbom validation failures because their pom:scm:url is invalid (json-schema-validator and itu).  I opened an issue with json-schema-validator to see what they say.  ~~I will probably just exclude these two until they fix it.~~  There is no way to exclude third-party deps from the SBOM report that I can see, we will have to wait for their fix in order for SBOM to be valid.

**Other note about `<includeTools>false</includeTools>` in the repackage plugin.**  I noticed a spring-boot-jarmode-tools jar file being included in the uber jar, and I didn't know what it was.  After research, I don't think we need it, so I excluded it with the change.  https://docs.spring.io/spring-boot/maven-plugin/packaging.html#packaging.examples.layered-archive-tools

**This PR is dependent on the main PR: https://github.com/eclipse-pass/main/pull/1086.** To test this PR, first checkout that PR and mvn clean install, then you can run mvn clean install on this PR.