### PR TITLE
Add JaCoCo for Code Coverage Reports in Pass Core

### DIFF
--- a/jacoco-aggregate-report/pom.xml
+++ b/jacoco-aggregate-report/pom.xml
@@ -12,9 +12,6 @@
     <packaging>pom</packaging>
 
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/jacoco-aggregate-report/pom.xml
+++ b/jacoco-aggregate-report/pom.xml
@@ -38,6 +38,21 @@
             <artifactId>pass-core-object-service</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.pass</groupId>
+            <artifactId>pass-core-policy-service</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.pass</groupId>
+            <artifactId>pass-core-user-service</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.pass</groupId>
+            <artifactId>pass-core-usertoken</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/jacoco-aggregate-report/pom.xml
+++ b/jacoco-aggregate-report/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.eclipse.pass</groupId>
         <artifactId>pass-core</artifactId>
@@ -8,6 +9,7 @@
     </parent>
 
     <artifactId>jacoco-aggregate-report</artifactId>
+    <packaging>pom</packaging>
 
     <properties>
         <maven.compiler.source>23</maven.compiler.source>
@@ -15,24 +17,35 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.eclipse.pass</groupId>
-                <artifactId>pass-core-doi-service</artifactId>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.pass</groupId>
-                <artifactId>pass-core-file-service</artifactId>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.pass</groupId>
+            <artifactId>pass-core-doi-service</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.pass</groupId>
+            <artifactId>pass-core-file-service</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.pass</groupId>
+            <artifactId>pass-core-metadataschema-service</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.pass</groupId>
+            <artifactId>pass-core-object-service</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
 
     <build>
         <plugins>
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>report-aggregate</id>
@@ -45,6 +58,4 @@
             </plugin>
         </plugins>
     </build>
-
-
 </project>

--- a/jacoco-aggregate-report/pom.xml
+++ b/jacoco-aggregate-report/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.eclipse.pass</groupId>
+        <artifactId>pass-core</artifactId>
+        <version>1.14.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>jacoco-aggregate-report</artifactId>
+
+    <properties>
+        <maven.compiler.source>23</maven.compiler.source>
+        <maven.compiler.target>23</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.eclipse.pass</groupId>
+                <artifactId>pass-core-doi-service</artifactId>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.pass</groupId>
+                <artifactId>pass-core-file-service</artifactId>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>report-aggregate</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report-aggregate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+
+</project>

--- a/jacoco-aggregate-report/pom.xml
+++ b/jacoco-aggregate-report/pom.xml
@@ -35,6 +35,17 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.pass</groupId>
+            <artifactId>pass-core-main</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.ow2.asm</groupId>
+                    <artifactId>asm-tree</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.pass</groupId>
             <artifactId>pass-core-object-service</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/jacoco-aggregate-report/pom.xml
+++ b/jacoco-aggregate-report/pom.xml
@@ -12,8 +12,8 @@
     <packaging>pom</packaging>
 
     <properties>
-        <maven.compiler.source>23</maven.compiler.source>
-        <maven.compiler.target>23</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/pass-core-doi-service/pom.xml
+++ b/pass-core-doi-service/pom.xml
@@ -48,6 +48,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>prepare-agent</id>

--- a/pass-core-doi-service/pom.xml
+++ b/pass-core-doi-service/pom.xml
@@ -42,4 +42,22 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/pass-core-file-service/pom.xml
+++ b/pass-core-file-service/pom.xml
@@ -60,4 +60,22 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/pass-core-file-service/pom.xml
+++ b/pass-core-file-service/pom.xml
@@ -3,8 +3,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <artifactId>pass-core</artifactId>
         <groupId>org.eclipse.pass</groupId>
+        <artifactId>pass-core</artifactId>
         <version>1.14.0-SNAPSHOT</version>
     </parent>
 
@@ -66,6 +66,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>prepare-agent</id>

--- a/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/storage/FileStorageService.java
+++ b/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/storage/FileStorageService.java
@@ -82,6 +82,10 @@ public class FileStorageService {
 
     /**
      *  FileStorageService Class constructor.
+     *
+     * @param ocflRepository ocfl object that is a layer to handle the io of the files
+     * @param storageProperties properties indicating where and what type of storage is used for persistence.
+     * @param rootLoc path of the root location used to set up temp working directory for the File Service
      */
     public FileStorageService(OcflRepository ocflRepository,
                               StorageProperties storageProperties,

--- a/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/storage/StorageConfiguration.java
+++ b/pass-core-file-service/src/main/java/org/eclipse/pass/file/service/storage/StorageConfiguration.java
@@ -59,6 +59,11 @@ public class StorageConfiguration {
     @Value("${aws.region}")
     private String awsRegion;
 
+    /**
+     * Creates and configures an S3TransferManager for managing file transfers to Amazon S3.
+     *
+     * @return a configured S3TransferManager instance.
+     */
     @Bean
     @ConditionalOnProperty(name = "pass.file-service.storage-type", havingValue = "S3")
     public S3TransferManager s3TransferManager() {
@@ -72,6 +77,13 @@ public class StorageConfiguration {
             .build();
     }
 
+    /**
+     * Creates and configures an S3AsyncClient for interacting with Amazon S3 or an S3-compatible storage service.
+     *
+     * @param storageProperties the StorageProperties containing the configuration.
+     * @return a configured S3AsyncClient instance.
+     * @throws IOException if the S3 bucket name is not set in StorageProperties.
+     */
     @Bean
     @ConditionalOnProperty(name = "pass.file-service.storage-type", havingValue = "S3")
     public S3AsyncClient s3Client(StorageProperties storageProperties) throws IOException {
@@ -93,6 +105,17 @@ public class StorageConfiguration {
         return s3Client;
     }
 
+    /**
+     * Creates and configures an OcflRepository instance for use with Amazon S3 as the storage backend.
+     *
+     * @param s3Client           the S3AsyncClient for interacting with Amazon S3.
+     * @param s3TransferManager  the S3TransferManager to manage file transfers to S3.
+     * @param storageProperties  the StorageProperties containing the configuration.
+     * @param rootLoc            the root Path for the file service.
+     * @return a OcflRepository instance, using S3 as the storage layer.
+     * @throws IOException if the S3 bucket name is not set in the StorageProperties, or if there are
+     *                     issues creating or accessing the working directory.
+     */
     @Bean
     @ConditionalOnProperty(name = "pass.file-service.storage-type", havingValue = "S3")
     public OcflRepository ocflS3Repository(S3AsyncClient s3Client, S3TransferManager s3TransferManager,
@@ -121,6 +144,17 @@ public class StorageConfiguration {
         return ocflRepository;
     }
 
+    /**
+     * Creates and configures an {@link OcflRepository} instance when the file service storage type
+     * is set to "FILE_SYSTEM". This method ensures that the OCFL directory exists, is accessible,
+     * and is properly set up with the required permissions.
+     *
+     * @param storageProperties the StorageProperties object containing storage configurations.
+     * @param rootLoc the root Path where the OCFL directory will be created or accessed.
+     * @return a fully configured OcflRepository instance backed by a file system storage type.
+     * @throws IOException if the OCFL directory cannot be created, or if there are insufficient
+     *                     read/write permissions.
+     */
     @Bean
     @ConditionalOnProperty(name = "pass.file-service.storage-type", havingValue = "FILE_SYSTEM")
     public OcflRepository ocflFileRepository(StorageProperties storageProperties,
@@ -142,6 +176,13 @@ public class StorageConfiguration {
         return ocflRepository;
     }
 
+    /**
+     * Configures and provides the root Path for the file service storage.
+     *
+     * @param storageProperties the StorageProperties object containing storage configuration details.
+     * @return the root Path for the storage system.
+     * @throws IOException if an error occurs while creating the temporary directory.
+     */
     @Bean
     @Qualifier("rootPath")
     public Path rootPath(StorageProperties storageProperties) throws IOException {

--- a/pass-core-main/pom.xml
+++ b/pass-core-main/pom.xml
@@ -257,6 +257,20 @@
         <artifactId>cyclonedx-maven-plugin</artifactId>
       </plugin>
 
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>${jacoco-maven-plugin.version}</version>
+        <executions>
+          <execution>
+            <id>prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
     </plugins>
   </build>
 </project>

--- a/pass-core-metadataschema-service/pom.xml
+++ b/pass-core-metadataschema-service/pom.xml
@@ -33,4 +33,22 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/pass-core-object-service/pom.xml
+++ b/pass-core-object-service/pom.xml
@@ -31,4 +31,23 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>${jacoco-maven-plugin.version}</version>
+        <executions>
+          <execution>
+            <id>prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/pass-core-policy-service/pom.xml
+++ b/pass-core-policy-service/pom.xml
@@ -36,4 +36,22 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>${jacoco-maven-plugin.version}</version>
+        <executions>
+          <execution>
+            <id>prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/pass-core-user-service/pom.xml
+++ b/pass-core-user-service/pom.xml
@@ -40,4 +40,23 @@
             <version>${jakarta.json.version}</version>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/pass-core-usertoken/pom.xml
+++ b/pass-core-usertoken/pom.xml
@@ -24,4 +24,23 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
     <module>pass-core-policy-service</module>
     <module>pass-core-usertoken</module>
     <module>pass-core-test-config</module>
+    <module>jacoco-aggregate-report</module>
   </modules>
 
   <scm>
@@ -320,19 +321,7 @@
               <goal>prepare-agent</goal>
             </goals>
           </execution>
-          <execution>
-            <id>report-aggregate</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>report-aggregate</goal>
-            </goals>
-          </execution>
         </executions>
-        <configuration>
-          <outputDirectory>${project.reporting.outputDirectory}/jacoco-aggregate</outputDirectory>
-          <dataFile>${project.build.directory}/jacoco.exec</dataFile>
-          <append>true</append>
-        </configuration>
       </plugin>
 
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -328,6 +328,11 @@
             </goals>
           </execution>
         </executions>
+        <configuration>
+          <outputDirectory>${project.reporting.outputDirectory}/jacoco-aggregate</outputDirectory>
+          <dataFile>${project.build.directory}/jacoco.exec</dataFile>
+          <append>true</append>
+        </configuration>
       </plugin>
 
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
 
     <apache.commons.io.version>2.17.0</apache.commons.io.version>
     <jsoup.version>1.18.1</jsoup.version>
+    <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
   </properties>
 
   <repositories>
@@ -307,6 +308,28 @@
           </execution>
         </executions>
       </plugin>
+
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>${jacoco-maven-plugin.version}</version>
+        <executions>
+          <execution>
+            <id>prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report-aggregate</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>report-aggregate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
This PR will add JaCoCo (Java Code Coverage) to the pass-core project. It is mostly the default configuration for JaCoCo. The reports are aggregated into the `jacoco-aggregate-report` module. In my research this is the approach to take when setting up an aggregate report to be consumed by a report service like SonarQube.  

- Report can be found in `target/site/jacoco/index.html` in the `jacoco-aggregate-report` module
   - Reports on individual classes are found in subfolders such as `target/site/jacoco/org.eclipse.pass.support.client` etc. These can be navigated to by using the `index.html`
- I removed the coverage ratio so it wouldn't fail the build as we determined in our last status meeting, the first iteration will be just to view the reports and then determine what type of metrics to fail a build.
- There was some minor javadoc added to the FileService.

To generate the reports:
- run `mvn verify`