### PR TITLE
Enable CSRF for /logout

### DIFF
--- a/pass-core-main/src/main/java/org/eclipse/pass/main/security/SecurityConfiguration.java
+++ b/pass-core-main/src/main/java/org/eclipse/pass/main/security/SecurityConfiguration.java
@@ -85,10 +85,8 @@ public class SecurityConfiguration {
         // Enable CSRF protection using a cookie to send the token. See
         // https://docs.spring.io/spring-security/reference/servlet/exploits/csrf.html#csrf-integration-javascript-spa
         // Make sure the cookie value can be parsed when returned in a header
-        // Do not protect /logout so it can be triggered with GET
         // Ensure that GET requests to the doi service are protected since they have side effects
         http.csrf(csrf -> csrf.csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
-                .ignoringRequestMatchers("/logout")
                 .requireCsrfProtectionMatcher(new OrRequestMatcher(CsrfFilter.DEFAULT_CSRF_MATCHER,
                         new AntPathRequestMatcher("/doi/**")))
                 .csrfTokenRequestHandler(new SpaCsrfTokenRequestHandler()));
@@ -124,8 +122,6 @@ public class SecurityConfiguration {
 
         http.saml2Metadata(Customizer.withDefaults());
 
-        http.saml2Logout(Customizer.withDefaults());
-
         // Delete specified cookies on logout.
         // Each cookie is specified as a name and path separated by whitespace.
         Cookie[] cookies = logoutDeleteCookies.stream().map(s -> {
@@ -137,10 +133,9 @@ public class SecurityConfiguration {
             return c;
         }).toArray(Cookie[]::new);
 
-        // Allow GET on /logout
         CookieClearingLogoutHandler logoutHandler = new CookieClearingLogoutHandler(cookies);
-        http.logout(l -> l.logoutSuccessUrl(logoutSuccessUrl).
-                logoutRequestMatcher(new AntPathRequestMatcher("/logout")).addLogoutHandler(logoutHandler));
+        http.logout(l -> l.logoutSuccessUrl(logoutSuccessUrl)
+                .addLogoutHandler(logoutHandler));
 
         // Map SAML user to PASS user
         http.addFilterAfter(passAuthFilter, Saml2WebSsoAuthenticationFilter.class);

--- a/pass-core-main/src/test/java/org/eclipse/pass/main/security/AccessControlTest.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/main/security/AccessControlTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
@@ -799,14 +800,21 @@ public class AccessControlTest extends SamlIntegrationTest {
         {
             String url = getBaseUrl() + "logout";
 
-            Request request = new Request.Builder().url(url).get().build();
+            RequestBody body = RequestBody.create("{}", JSON_API_MEDIA_TYPE);
+            Request request = new Request.Builder().url(url)
+                .header("Accept", JSON_API_CONTENT_TYPE)
+                .header("Content-Type", JSON_API_CONTENT_TYPE)
+                .header("X-XSRF-TOKEN", getCsrfToken())
+                .post(body).build();
             Response response = client.newCall(request).execute();
 
-            assertEquals(204, response.code());
+            assertEquals(200, response.code());
+            assertEquals("http://localhost:8080/login", response.request().url().toString());
+            assertTrue(response.priorResponse().isRedirect());
         }
 
         // Session cookie deleted
-        assertEquals(null, get_cookie("JSESSIONID"));
+        assertNull(get_cookie("JSESSIONID"));
 
         {
             String url = getBaseUrl() + "app/";


### PR DESCRIPTION
This PR enables CSRF requirement for the `/logout` endpoint.

Note the removal of `http.saml2Logout` from the security configuration.  This is needed so the SAML SLO logout doesn't execute when a POST is sent to `/logout`.  I assume this is what we want because in the previous configuration, SAML SLO logout was essentially disabled because it only executes for POST requests, so it was being skipped for the GET `/logout` requests.  Let me know if I missed something with this assumption.

There will also be a `pass-ui` PR that must be merged with this PR. https://github.com/eclipse-pass/pass-ui/pull/1294