### PR TITLE
Rename jacoco-aggregate-report

### DIFF
--- a/jacoco-aggregate-report-pass-core/pom.xml
+++ b/jacoco-aggregate-report-pass-core/pom.xml
@@ -8,7 +8,7 @@
         <version>1.14.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>jacoco-aggregate-report</artifactId>
+    <artifactId>jacoco-aggregate-report-pass-core</artifactId>
     <packaging>pom</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <module>pass-core-policy-service</module>
     <module>pass-core-usertoken</module>
     <module>pass-core-test-config</module>
-    <module>jacoco-aggregate-report</module>
+    <module>jacoco-aggregate-report-pass-core</module>
   </modules>
 
   <scm>


### PR DESCRIPTION
To fix release workflow issue of duplicate name.