### PR TITLE
Revert "Change h2 dep to test scope"

### DIFF
--- a/pass-core-main/pom.xml
+++ b/pass-core-main/pom.xml
@@ -84,6 +84,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+    </dependency>
+    
+    <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
     </dependency>
@@ -194,12 +199,6 @@
       <groupId>org.eclipse.pass</groupId>
       <artifactId>pass-core-test-config</artifactId>
       <version>${project.parent.version}</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
This reverts commit 4080fcb4007f065b1053de90f86abc93031633e4.  h2 is needed in compile scope so that integration tests in pass-support work.

This means this comment in https://github.com/eclipse-pass/pass-core/pull/118 is relevant:

The only Security Vulnerability left is the h2 dependency vulnerability. Looks like this is a false positive and being flagged by bad info in OSS: https://github.com/OSSIndex/vulns/issues/277. Not sure why it is showing up still, but pass-core h2 version is 2.3.232, which based on a couple sites I checked looks clean: https://deps.dev/maven/com.h2database%3Ah2/2.3.232. Also, pass-core uses h2 only for local non-production testing.