### PR TITLE
Change DOI lookup Journal update rules

### DIFF
--- a/pass-core-main/src/test/java/org/eclipse/pass/doi/service/DoiServiceTest.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/doi/service/DoiServiceTest.java
@@ -1,10 +1,28 @@
+/*
+ * Copyright 2025 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.eclipse.pass.doi.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.StringReader;
+import java.util.List;
 
 import com.yahoo.elide.RefreshableElide;
 import jakarta.json.Json;
@@ -22,12 +40,13 @@ import org.eclipse.pass.object.PassClientResult;
 import org.eclipse.pass.object.PassClientSelector;
 import org.eclipse.pass.object.RSQL;
 import org.eclipse.pass.object.model.Journal;
+import org.eclipse.pass.object.model.PmcParticipation;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public class DoiServiceTest extends SimpleIntegrationTest {
-    private static String credentials = Credentials.basic(BACKEND_USER, BACKEND_PASSWORD);
+    private static final String credentials = Credentials.basic(BACKEND_USER, BACKEND_PASSWORD);
 
     @Autowired
     protected RefreshableElide refreshableElide;
@@ -41,6 +60,17 @@ public class DoiServiceTest extends SimpleIntegrationTest {
     @BeforeEach
     protected void setupClient() throws IOException {
         httpClient = newOkhttpClient();
+        try (PassClient passClient = getNewClient()) {
+            PassClientSelector<Journal> journalSelector = new PassClientSelector<>(Journal.class);
+            List<Journal> testJournals = passClient.streamObjects(journalSelector).toList();
+            testJournals.forEach(testJournal -> {
+                try {
+                    passClient.deleteObject(testJournal);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        }
     }
 
     /**
@@ -59,8 +89,8 @@ public class DoiServiceTest extends SimpleIntegrationTest {
         Call call = httpClient.newCall(okHttpRequest);
         try (Response okHttpResponse = call.execute()) {
             assertEquals(400, okHttpResponse.code());
+            assert okHttpResponse.body() != null;
             String body = okHttpResponse.body().string();
-            assert body != null;
             assertEquals("{\"error\":\"Supplied DOI is not in valid DOI format.\"}",
                          body);
 
@@ -83,8 +113,8 @@ public class DoiServiceTest extends SimpleIntegrationTest {
         Call call = httpClient.newCall(okHttpRequest);
         try (Response okHttpResponse = call.execute()) {
             assertEquals(400, okHttpResponse.code());
+            assert okHttpResponse.body() != null;
             String body = okHttpResponse.body().string();
-            assert body != null;
             assertEquals("{\"error\":\"Supplied DOI is not in valid DOI format.\"}",
                          body);
 
@@ -108,8 +138,8 @@ public class DoiServiceTest extends SimpleIntegrationTest {
         Call call = httpClient.newCall(okHttpRequest);
         try (Response okHttpResponse = call.execute()) {
             assertEquals(404, okHttpResponse.code());
+            assert okHttpResponse.body() != null;
             String body = okHttpResponse.body().string();
-            assert body != null;
             assertEquals("{\"error\":\"The resource for DOI 10.1212/abc.DEF could not be found on Crossref.\"}",
                          body);
 
@@ -136,38 +166,20 @@ public class DoiServiceTest extends SimpleIntegrationTest {
         Call call = httpClient.newCall(okHttpRequest);
         try (Response okHttpResponse = call.execute()) {
             assertEquals(422, okHttpResponse.code());
+            assert okHttpResponse.body() != null;
             String body = okHttpResponse.body().string();
-            assert body != null;
             assertEquals("{\"error\":\"Insufficient information to locate or specify a journal entry.\"}",
                          body);
         }
     }
 
     @Test
-    public void realJournalTest() {
+    public void testCreateJournal() {
         String name = "Clinical Medicine Insights: Cardiology";
         HttpUrl url = formDoiUrl("10.4137/cmc.s38446" );
         String id = "";
 
         try (PassClient passClient = getNewClient()) {
-            //if this journal is in the database already, delete it
-            String filter = RSQL.equals("journalName", name);
-            PassClientResult<Journal> result = passClient.
-                selectObjects(new PassClientSelector<>(Journal.class, 0, 100, filter, null));
-            result.getObjects().forEach(j -> {
-                try {
-                    passClient.deleteObject(Journal.class, j.getId());
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
-            });
-
-            //verify that this journal is not in the database
-            filter = RSQL.equals("journalName", name);
-            result = passClient.
-                selectObjects(new PassClientSelector<>(Journal.class, 0, 100, filter, null));
-            assertEquals(0, result.getObjects().size());
-
             Request okHttpRequest = new Request.Builder()
                 .url(url).header("Authorization", credentials)
                 .header("X-XSRF-TOKEN", getCsrfToken(httpClient))
@@ -176,28 +188,28 @@ public class DoiServiceTest extends SimpleIntegrationTest {
             Call call = httpClient.newCall(okHttpRequest);
             try (Response okHttpResponse = call.execute()) {
                 assertEquals(200, okHttpResponse.code());
+                assert okHttpResponse.body() != null;
                 String body = okHttpResponse.body().string();
-                assert body != null;
                 JsonReader jsonReader1 = Json.createReader(new StringReader(body));
                 JsonObject successReport = jsonReader1.readObject();
                 jsonReader1.close();
                 assertNotNull(successReport.getString("journal-id"));
                 id = successReport.getString("journal-id");
-
-                //verify that this journal is now in the database
-                filter = RSQL.equals("journalName", name);
-                result = passClient.
-                    selectObjects(new PassClientSelector<>(Journal.class, 0, 100, filter, null));
-                assertEquals(1, result.getObjects().size());
             } catch (Exception e) {
                 e.printStackTrace();
             }
 
+            //verify that this journal is now in the database
+            String filter = RSQL.equals("journalName", name);
+            PassClientResult<Journal> result = passClient.
+                selectObjects(new PassClientSelector<>(Journal.class, 0, 100, filter, null));
+            assertEquals(1, result.getObjects().size());
+
             //verify that the returned object for the same request has the right id
             call = httpClient.newCall(okHttpRequest);
             try (Response okHttpResponse = call.execute()) {
+                assert okHttpResponse.body() != null;
                 String body = okHttpResponse.body().string();
-                assert body != null;
                 JsonReader jsonReader2 = Json.createReader(new StringReader(body));
                 JsonObject successReport = jsonReader2.readObject();
                 jsonReader2.close();
@@ -213,6 +225,117 @@ public class DoiServiceTest extends SimpleIntegrationTest {
             assertEquals(1, result.getObjects().size());
         } catch (Exception e) {
             e.printStackTrace();
+        }
+    }
+
+    @Test
+    public void testUpdateJournal() throws Exception {
+        final String expectedJournalName = "Publications of the Astronomical Society of the Pacific";
+        final HttpUrl doiUrl = formDoiUrl("10.1086/655938" );
+        Journal newJournal = new Journal();
+        newJournal.setJournalName("TestUpdate: " + expectedJournalName);
+        newJournal.setIssns(List.of("Online:1538-3873"));
+
+        executeDoiCalls(newJournal, doiUrl);
+
+        try (PassClient passClient = getNewClient()) {
+            //verify that this journal is now in the database
+            String filter = RSQL.equals("journalName", expectedJournalName);
+            PassClientResult<Journal> result = passClient.
+                selectObjects(new PassClientSelector<>(Journal.class, 0, 100, filter, null));
+            assertEquals(1, result.getObjects().size());
+
+            Journal updatedJournal = passClient.getObject(Journal.class, newJournal.getId());
+            assertEquals(expectedJournalName, updatedJournal.getJournalName());
+            assertNull(updatedJournal.getNlmta());
+            assertEquals(2, updatedJournal.getIssns().size());
+            assertTrue(updatedJournal.getIssns().contains("Online:1538-3873"));
+            assertTrue(updatedJournal.getIssns().contains("Print:0004-6280"));
+        }
+    }
+
+    @Test
+    public void testNoUpdateJournalNlmtaNotNull() throws Exception {
+        final String expectedJournalName = "Publications of the Astronomical Society of the Pacific";
+        final HttpUrl doiUrl = formDoiUrl("10.1086/655938" );
+        Journal newJournal = new Journal();
+        newJournal.setJournalName("TestUpdate: " + expectedJournalName);
+        newJournal.setIssns(List.of("Online:1538-3873"));
+        newJournal.setNlmta("Publ Astron Soc Pac");
+
+        executeDoiCalls(newJournal, doiUrl);
+
+        try (PassClient passClient = getNewClient()) {
+            String filter = RSQL.equals("journalName", expectedJournalName);
+            PassClientResult<Journal> result = passClient.
+                selectObjects(new PassClientSelector<>(Journal.class, 0, 100, filter, null));
+            assertEquals(0, result.getObjects().size());
+
+            filter = RSQL.equals("journalName", "TestUpdate: " + expectedJournalName);
+            result = passClient.
+                selectObjects(new PassClientSelector<>(Journal.class, 0, 100, filter, null));
+            assertEquals(1, result.getObjects().size());
+
+            Journal actualJournal = passClient.getObject(Journal.class, newJournal.getId());
+            assertEquals("TestUpdate: " + expectedJournalName, actualJournal.getJournalName());
+            assertEquals("Publ Astron Soc Pac", actualJournal.getNlmta());
+            assertEquals(1, actualJournal.getIssns().size());
+            assertTrue(actualJournal.getIssns().contains("Online:1538-3873"));
+        }
+    }
+
+    @Test
+    public void testNoUpdateJournalPmcPartNotNull() throws Exception {
+        final String expectedJournalName = "Publications of the Astronomical Society of the Pacific";
+        final HttpUrl doiUrl = formDoiUrl("10.1086/655938" );
+        Journal newJournal = new Journal();
+        newJournal.setJournalName("TestUpdate: " + expectedJournalName);
+        newJournal.setIssns(List.of("Online:1538-3873"));
+        newJournal.setPmcParticipation(PmcParticipation.A);
+
+        executeDoiCalls(newJournal, doiUrl);
+
+        try (PassClient passClient = getNewClient()) {
+            String filter = RSQL.equals("journalName", expectedJournalName);
+            PassClientResult<Journal> result = passClient.
+                selectObjects(new PassClientSelector<>(Journal.class, 0, 100, filter, null));
+            assertEquals(0, result.getObjects().size());
+
+            filter = RSQL.equals("journalName", "TestUpdate: " + expectedJournalName);
+            result = passClient.
+                selectObjects(new PassClientSelector<>(Journal.class, 0, 100, filter, null));
+            assertEquals(1, result.getObjects().size());
+
+            Journal actualJournal = passClient.getObject(Journal.class, newJournal.getId());
+            assertEquals("TestUpdate: " + expectedJournalName, actualJournal.getJournalName());
+            assertNull(actualJournal.getNlmta());
+            assertEquals(1, actualJournal.getIssns().size());
+            assertTrue(actualJournal.getIssns().contains("Online:1538-3873"));
+        }
+    }
+
+    private void executeDoiCalls(Journal newJournal, HttpUrl doiUrl) throws Exception {
+        try (PassClient passClient = getNewClient()) {
+            passClient.createObject(newJournal);
+
+            Request okHttpRequest = new Request.Builder()
+                .url(doiUrl).header("Authorization", credentials)
+                .header("X-XSRF-TOKEN", getCsrfToken(httpClient))
+                .build();
+
+            String id;
+            Call call = httpClient.newCall(okHttpRequest);
+            try (Response okHttpResponse = call.execute()) {
+                assertEquals(200, okHttpResponse.code());
+                assert okHttpResponse.body() != null;
+                String body = okHttpResponse.body().string();
+                JsonReader jsonReader1 = Json.createReader(new StringReader(body));
+                JsonObject successReport = jsonReader1.readObject();
+                jsonReader1.close();
+                assertNotNull(successReport.getString("journal-id"));
+                id = successReport.getString("journal-id");
+                assertEquals(newJournal.getId(), Long.parseLong(id));
+            }
         }
     }
 

--- a/pass-core-main/src/test/java/org/eclipse/pass/doi/service/DoiServiceTest.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/doi/service/DoiServiceTest.java
@@ -258,6 +258,7 @@ class DoiServiceTest extends SimpleIntegrationTest {
             Journal updatedJournal = passClient.getObject(Journal.class, newJournal.getId());
             assertEquals(expectedJournalName, updatedJournal.getJournalName());
             assertNull(updatedJournal.getNlmta());
+            assertNull(updatedJournal.getPmcParticipation());
             assertEquals(2, updatedJournal.getIssns().size());
             assertTrue(updatedJournal.getIssns().contains("Online:1538-3873"));
             assertTrue(updatedJournal.getIssns().contains("Print:0004-6280"));
@@ -289,6 +290,7 @@ class DoiServiceTest extends SimpleIntegrationTest {
             Journal actualJournal = passClient.getObject(Journal.class, newJournal.getId());
             assertEquals("TestUpdate: " + expectedJournalName, actualJournal.getJournalName());
             assertEquals("TestNlmta", actualJournal.getNlmta());
+            assertNull(actualJournal.getPmcParticipation());
             assertEquals(1, actualJournal.getIssns().size());
             assertTrue(actualJournal.getIssns().contains("Online:1538-3873"));
         }
@@ -301,7 +303,7 @@ class DoiServiceTest extends SimpleIntegrationTest {
         Journal newJournal = new Journal();
         newJournal.setJournalName("TestUpdate: " + expectedJournalName);
         newJournal.setIssns(List.of("Online:1538-3873"));
-        newJournal.setPmcParticipation(PmcParticipation.A);
+        newJournal.setPmcParticipation(PmcParticipation.D);
 
         executeDoiCalls(newJournal, doiUrl);
 
@@ -319,6 +321,7 @@ class DoiServiceTest extends SimpleIntegrationTest {
             Journal actualJournal = passClient.getObject(Journal.class, newJournal.getId());
             assertEquals("TestUpdate: " + expectedJournalName, actualJournal.getJournalName());
             assertNull(actualJournal.getNlmta());
+            assertEquals(PmcParticipation.D, actualJournal.getPmcParticipation());
             assertEquals(1, actualJournal.getIssns().size());
             assertTrue(actualJournal.getIssns().contains("Online:1538-3873"));
         }

--- a/pass-core-main/src/test/java/org/eclipse/pass/doi/service/DoiServiceTest.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/doi/service/DoiServiceTest.java
@@ -41,6 +41,7 @@ import org.eclipse.pass.object.PassClientSelector;
 import org.eclipse.pass.object.RSQL;
 import org.eclipse.pass.object.model.Journal;
 import org.eclipse.pass.object.model.PmcParticipation;
+import org.eclipse.pass.object.model.Publication;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -61,6 +62,15 @@ public class DoiServiceTest extends SimpleIntegrationTest {
     protected void setupClient() throws IOException {
         httpClient = newOkhttpClient();
         try (PassClient passClient = getNewClient()) {
+            PassClientSelector<Publication> publicationSelector = new PassClientSelector<>(Publication.class);
+            List<Publication> testPublications = passClient.streamObjects(publicationSelector).toList();
+            testPublications.forEach(testPublication -> {
+                try {
+                    passClient.deleteObject(testPublication);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
             PassClientSelector<Journal> journalSelector = new PassClientSelector<>(Journal.class);
             List<Journal> testJournals = passClient.streamObjects(journalSelector).toList();
             testJournals.forEach(testJournal -> {

--- a/pass-core-main/src/test/java/org/eclipse/pass/doi/service/DoiServiceTest.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/doi/service/DoiServiceTest.java
@@ -46,8 +46,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-public class DoiServiceTest extends SimpleIntegrationTest {
-    private static final String credentials = Credentials.basic(BACKEND_USER, BACKEND_PASSWORD);
+class DoiServiceTest extends SimpleIntegrationTest {
+    private static final String CREDENTIALS = Credentials.basic(BACKEND_USER, BACKEND_PASSWORD);
 
     @Autowired
     protected RefreshableElide refreshableElide;
@@ -89,11 +89,11 @@ public class DoiServiceTest extends SimpleIntegrationTest {
      * @throws Exception if something goes wrong
      */
     @Test
-    public void invalidDoiTest() throws Exception {
+    void invalidDoiTest() throws Exception {
         HttpUrl url = formDoiUrl("moo");
 
         Request okHttpRequest = new Request.Builder()
-            .url(url).header("Authorization", credentials)
+            .url(url).header("Authorization", CREDENTIALS)
             .header("X-XSRF-TOKEN", getCsrfToken(httpClient))
             .build();
         Call call = httpClient.newCall(okHttpRequest);
@@ -113,11 +113,11 @@ public class DoiServiceTest extends SimpleIntegrationTest {
      * @throws Exception if something goes wrong
      */
     @Test
-    public void nullDoiTest() throws Exception {
+    void nullDoiTest() throws Exception {
         HttpUrl url = formDoiUrl(null);
 
         Request okHttpRequest = new Request.Builder()
-            .url(url).header("Authorization", credentials)
+            .url(url).header("Authorization", CREDENTIALS)
             .header("X-XSRF-TOKEN", getCsrfToken(httpClient))
             .build();
         Call call = httpClient.newCall(okHttpRequest);
@@ -137,12 +137,12 @@ public class DoiServiceTest extends SimpleIntegrationTest {
      * @throws Exception if something goes wrong
      */
     @Test
-    public void noSuchDoiTest() throws Exception {
+    void noSuchDoiTest() throws Exception {
 
         HttpUrl url = formDoiUrl( "10.1212/abc.DEF");
 
         Request okHttpRequest = new Request.Builder()
-            .url(url).header("Authorization", credentials)
+            .url(url).header("Authorization", CREDENTIALS)
             .header("X-XSRF-TOKEN", getCsrfToken(httpClient))
             .build();
         Call call = httpClient.newCall(okHttpRequest);
@@ -164,13 +164,13 @@ public class DoiServiceTest extends SimpleIntegrationTest {
      * @throws Exception if something goes wrong
      */
     @Test
-    public void bookDoiFailTest() throws Exception {
+    void bookDoiFailTest() throws Exception {
         // books have isbn, not issn - this should cause a failure
 
         HttpUrl url = formDoiUrl("10.1002/0470841559.ch1");
 
         Request okHttpRequest = new Request.Builder()
-            .url(url).header("Authorization", credentials)
+            .url(url).header("Authorization", CREDENTIALS)
             .header("X-XSRF-TOKEN", getCsrfToken(httpClient))
             .build();
         Call call = httpClient.newCall(okHttpRequest);
@@ -184,14 +184,14 @@ public class DoiServiceTest extends SimpleIntegrationTest {
     }
 
     @Test
-    public void testCreateJournal() {
+    void testCreateJournal() {
         String name = "Clinical Medicine Insights: Cardiology";
         HttpUrl url = formDoiUrl("10.4137/cmc.s38446" );
         String id = "";
 
         try (PassClient passClient = getNewClient()) {
             Request okHttpRequest = new Request.Builder()
-                .url(url).header("Authorization", credentials)
+                .url(url).header("Authorization", CREDENTIALS)
                 .header("X-XSRF-TOKEN", getCsrfToken(httpClient))
                 .build();
 
@@ -239,7 +239,7 @@ public class DoiServiceTest extends SimpleIntegrationTest {
     }
 
     @Test
-    public void testUpdateJournal() throws Exception {
+    void testUpdateJournal() throws Exception {
         final String expectedJournalName = "Publications of the Astronomical Society of the Pacific";
         final HttpUrl doiUrl = formDoiUrl("10.1086/655938" );
         Journal newJournal = new Journal();
@@ -265,7 +265,7 @@ public class DoiServiceTest extends SimpleIntegrationTest {
     }
 
     @Test
-    public void testNoUpdateJournalNlmtaNotNull() throws Exception {
+    void testNoUpdateJournalNlmtaNotNull() throws Exception {
         final String expectedJournalName = "Publications of the Astronomical Society of the Pacific";
         final HttpUrl doiUrl = formDoiUrl("10.1086/655938" );
         Journal newJournal = new Journal();
@@ -295,7 +295,7 @@ public class DoiServiceTest extends SimpleIntegrationTest {
     }
 
     @Test
-    public void testNoUpdateJournalPmcPartNotNull() throws Exception {
+    void testNoUpdateJournalPmcPartNotNull() throws Exception {
         final String expectedJournalName = "Publications of the Astronomical Society of the Pacific";
         final HttpUrl doiUrl = formDoiUrl("10.1086/655938" );
         Journal newJournal = new Journal();
@@ -329,7 +329,7 @@ public class DoiServiceTest extends SimpleIntegrationTest {
             passClient.createObject(newJournal);
 
             Request okHttpRequest = new Request.Builder()
-                .url(doiUrl).header("Authorization", credentials)
+                .url(doiUrl).header("Authorization", CREDENTIALS)
                 .header("X-XSRF-TOKEN", getCsrfToken(httpClient))
                 .build();
 

--- a/pass-core-main/src/test/java/org/eclipse/pass/doi/service/DoiServiceTest.java
+++ b/pass-core-main/src/test/java/org/eclipse/pass/doi/service/DoiServiceTest.java
@@ -261,7 +261,7 @@ public class DoiServiceTest extends SimpleIntegrationTest {
         Journal newJournal = new Journal();
         newJournal.setJournalName("TestUpdate: " + expectedJournalName);
         newJournal.setIssns(List.of("Online:1538-3873"));
-        newJournal.setNlmta("Publ Astron Soc Pac");
+        newJournal.setNlmta("TestNlmta");
 
         executeDoiCalls(newJournal, doiUrl);
 
@@ -278,7 +278,7 @@ public class DoiServiceTest extends SimpleIntegrationTest {
 
             Journal actualJournal = passClient.getObject(Journal.class, newJournal.getId());
             assertEquals("TestUpdate: " + expectedJournalName, actualJournal.getJournalName());
-            assertEquals("Publ Astron Soc Pac", actualJournal.getNlmta());
+            assertEquals("TestNlmta", actualJournal.getNlmta());
             assertEquals(1, actualJournal.getIssns().size());
             assertTrue(actualJournal.getIssns().contains("Online:1538-3873"));
         }


### PR DESCRIPTION
So that on DOI lookup, the associated Journal will only be updated if it is not updated by the journal loader. Also added updating of `Journal.journalName` if updates occur.