### PR TITLE
Add monthly schedule for CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: Continuous Integration
-on: [pull_request, workflow_dispatch]
+on:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '5 7 15 * *'
 
 jobs:
   test:


### PR DESCRIPTION
So that the sonarqube token is used and doesn't get removed after 60 days of no use.