### PR TITLE
Add pom elements in child modules for publish

### DIFF
--- a/jacoco-aggregate-report-pass-core/pom.xml
+++ b/jacoco-aggregate-report-pass-core/pom.xml
@@ -11,6 +11,57 @@
     <artifactId>jacoco-aggregate-report-pass-core</artifactId>
     <packaging>pom</packaging>
 
+    <name>PASS backend-jacoco-aggregate-report</name>
+    <description>PASS REST API implementation-jacoco-aggregate-report</description>
+
+    <url>https://github.com/eclipse-pass/pass-core</url>
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <name>Jim Martino</name>
+            <email>jrm@jhu.edu</email>
+            <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+            <organizationUrl>https://library.jhu.edu/</organizationUrl>
+        </developer>
+        <developer>
+            <name>Mark Patton</name>
+            <email>mpatton@jhu.edu</email>
+            <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+            <organizationUrl>https://library.jhu.edu/</organizationUrl>
+        </developer>
+        <developer>
+            <name>John Abrahams</name>
+            <email>jabrah20@jhu.edu</email>
+            <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+            <organizationUrl>https://library.jhu.edu/</organizationUrl>
+        </developer>
+        <developer>
+            <name>Tim Sanders</name>
+            <email>tsande16@jhu.edu</email>
+            <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+            <organizationUrl>https://library.jhu.edu/</organizationUrl>
+        </developer>
+        <developer>
+            <name>Russ Poetker</name>
+            <email>rpoetke1@jhu.edu</email>
+            <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+            <organizationUrl>https://library.jhu.edu/</organizationUrl>
+        </developer>
+    </developers>
+
+    <scm>
+        <connection>scm:git:https://github.com/eclipse-pass/pass-core.git</connection>
+        <developerConnection>scm:git:https://github.com/eclipse-pass/pass-core.git</developerConnection>
+        <url>https://github.com/eclipse-pass/pass-core</url>
+        <tag>HEAD</tag>
+    </scm>
+
     <properties>
     </properties>
 

--- a/pass-core-doi-service/pom.xml
+++ b/pass-core-doi-service/pom.xml
@@ -10,6 +10,57 @@
 
     <artifactId>pass-core-doi-service</artifactId>
 
+    <name>PASS backend-doi-service</name>
+    <description>PASS REST API implementation-doi-service</description>
+
+    <url>https://github.com/eclipse-pass/pass-core</url>
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <name>Jim Martino</name>
+            <email>jrm@jhu.edu</email>
+            <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+            <organizationUrl>https://library.jhu.edu/</organizationUrl>
+        </developer>
+        <developer>
+            <name>Mark Patton</name>
+            <email>mpatton@jhu.edu</email>
+            <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+            <organizationUrl>https://library.jhu.edu/</organizationUrl>
+        </developer>
+        <developer>
+            <name>John Abrahams</name>
+            <email>jabrah20@jhu.edu</email>
+            <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+            <organizationUrl>https://library.jhu.edu/</organizationUrl>
+        </developer>
+        <developer>
+            <name>Tim Sanders</name>
+            <email>tsande16@jhu.edu</email>
+            <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+            <organizationUrl>https://library.jhu.edu/</organizationUrl>
+        </developer>
+        <developer>
+            <name>Russ Poetker</name>
+            <email>rpoetke1@jhu.edu</email>
+            <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+            <organizationUrl>https://library.jhu.edu/</organizationUrl>
+        </developer>
+    </developers>
+
+    <scm>
+        <connection>scm:git:https://github.com/eclipse-pass/pass-core.git</connection>
+        <developerConnection>scm:git:https://github.com/eclipse-pass/pass-core.git</developerConnection>
+        <url>https://github.com/eclipse-pass/pass-core</url>
+        <tag>HEAD</tag>
+    </scm>
+
     <properties>
     </properties>
 

--- a/pass-core-file-service/pom.xml
+++ b/pass-core-file-service/pom.xml
@@ -10,6 +10,57 @@
 
     <artifactId>pass-core-file-service</artifactId>
 
+    <name>PASS backend-file-service</name>
+    <description>PASS REST API implementation-file-service</description>
+
+    <url>https://github.com/eclipse-pass/pass-core</url>
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <name>Jim Martino</name>
+            <email>jrm@jhu.edu</email>
+            <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+            <organizationUrl>https://library.jhu.edu/</organizationUrl>
+        </developer>
+        <developer>
+            <name>Mark Patton</name>
+            <email>mpatton@jhu.edu</email>
+            <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+            <organizationUrl>https://library.jhu.edu/</organizationUrl>
+        </developer>
+        <developer>
+            <name>John Abrahams</name>
+            <email>jabrah20@jhu.edu</email>
+            <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+            <organizationUrl>https://library.jhu.edu/</organizationUrl>
+        </developer>
+        <developer>
+            <name>Tim Sanders</name>
+            <email>tsande16@jhu.edu</email>
+            <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+            <organizationUrl>https://library.jhu.edu/</organizationUrl>
+        </developer>
+        <developer>
+            <name>Russ Poetker</name>
+            <email>rpoetke1@jhu.edu</email>
+            <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+            <organizationUrl>https://library.jhu.edu/</organizationUrl>
+        </developer>
+    </developers>
+
+    <scm>
+        <connection>scm:git:https://github.com/eclipse-pass/pass-core.git</connection>
+        <developerConnection>scm:git:https://github.com/eclipse-pass/pass-core.git</developerConnection>
+        <url>https://github.com/eclipse-pass/pass-core</url>
+        <tag>HEAD</tag>
+    </scm>
+
     <dependencies>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/pass-core-main/pom.xml
+++ b/pass-core-main/pom.xml
@@ -9,6 +9,57 @@
 
   <artifactId>pass-core-main</artifactId>
 
+  <name>PASS backend-main</name>
+  <description>PASS REST API implementation-main</description>
+
+  <url>https://github.com/eclipse-pass/pass-core</url>
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Jim Martino</name>
+      <email>jrm@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Mark Patton</name>
+      <email>mpatton@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>John Abrahams</name>
+      <email>jabrah20@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Tim Sanders</name>
+      <email>tsande16@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Russ Poetker</name>
+      <email>rpoetke1@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:https://github.com/eclipse-pass/pass-core.git</connection>
+    <developerConnection>scm:git:https://github.com/eclipse-pass/pass-core.git</developerConnection>
+    <url>https://github.com/eclipse-pass/pass-core</url>
+    <tag>HEAD</tag>
+  </scm>
+
   <repositories>
     <repository>
       <id>shibboleth-releases</id>

--- a/pass-core-object-service/pom.xml
+++ b/pass-core-object-service/pom.xml
@@ -9,6 +9,57 @@
 
   <artifactId>pass-core-object-service</artifactId>
 
+  <name>PASS backend-object-service</name>
+  <description>PASS REST API implementation-object-service</description>
+
+  <url>https://github.com/eclipse-pass/pass-core</url>
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Jim Martino</name>
+      <email>jrm@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Mark Patton</name>
+      <email>mpatton@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>John Abrahams</name>
+      <email>jabrah20@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Tim Sanders</name>
+      <email>tsande16@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Russ Poetker</name>
+      <email>rpoetke1@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:https://github.com/eclipse-pass/pass-core.git</connection>
+    <developerConnection>scm:git:https://github.com/eclipse-pass/pass-core.git</developerConnection>
+    <url>https://github.com/eclipse-pass/pass-core</url>
+    <tag>HEAD</tag>
+  </scm>
+
   <dependencies>
     <dependency>
       <groupId>com.yahoo.elide</groupId>

--- a/pass-core-policy-service/pom.xml
+++ b/pass-core-policy-service/pom.xml
@@ -9,6 +9,57 @@
 
   <artifactId>pass-core-policy-service</artifactId>
 
+  <name>PASS backend-policy-service</name>
+  <description>PASS REST API implementation-policy-service</description>
+
+  <url>https://github.com/eclipse-pass/pass-core</url>
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Jim Martino</name>
+      <email>jrm@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Mark Patton</name>
+      <email>mpatton@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>John Abrahams</name>
+      <email>jabrah20@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Tim Sanders</name>
+      <email>tsande16@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Russ Poetker</name>
+      <email>rpoetke1@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:https://github.com/eclipse-pass/pass-core.git</connection>
+    <developerConnection>scm:git:https://github.com/eclipse-pass/pass-core.git</developerConnection>
+    <url>https://github.com/eclipse-pass/pass-core</url>
+    <tag>HEAD</tag>
+  </scm>
+
   <properties>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>

--- a/pass-core-test-config/pom.xml
+++ b/pass-core-test-config/pom.xml
@@ -9,4 +9,55 @@
 
   <artifactId>pass-core-test-config</artifactId>
 
+  <name>PASS backend-test-config</name>
+  <description>PASS REST API implementation-test-config</description>
+
+  <url>https://github.com/eclipse-pass/pass-core</url>
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Jim Martino</name>
+      <email>jrm@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Mark Patton</name>
+      <email>mpatton@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>John Abrahams</name>
+      <email>jabrah20@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Tim Sanders</name>
+      <email>tsande16@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+    <developer>
+      <name>Russ Poetker</name>
+      <email>rpoetke1@jhu.edu</email>
+      <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+      <organizationUrl>https://library.jhu.edu/</organizationUrl>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:https://github.com/eclipse-pass/pass-core.git</connection>
+    <developerConnection>scm:git:https://github.com/eclipse-pass/pass-core.git</developerConnection>
+    <url>https://github.com/eclipse-pass/pass-core</url>
+    <tag>HEAD</tag>
+  </scm>
+
 </project>

--- a/pass-core-user-service/pom.xml
+++ b/pass-core-user-service/pom.xml
@@ -10,6 +10,57 @@
 
     <artifactId>pass-core-user-service</artifactId>
 
+    <name>PASS backend-user-service</name>
+    <description>PASS REST API implementation-user-service</description>
+
+    <url>https://github.com/eclipse-pass/pass-core</url>
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <name>Jim Martino</name>
+            <email>jrm@jhu.edu</email>
+            <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+            <organizationUrl>https://library.jhu.edu/</organizationUrl>
+        </developer>
+        <developer>
+            <name>Mark Patton</name>
+            <email>mpatton@jhu.edu</email>
+            <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+            <organizationUrl>https://library.jhu.edu/</organizationUrl>
+        </developer>
+        <developer>
+            <name>John Abrahams</name>
+            <email>jabrah20@jhu.edu</email>
+            <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+            <organizationUrl>https://library.jhu.edu/</organizationUrl>
+        </developer>
+        <developer>
+            <name>Tim Sanders</name>
+            <email>tsande16@jhu.edu</email>
+            <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+            <organizationUrl>https://library.jhu.edu/</organizationUrl>
+        </developer>
+        <developer>
+            <name>Russ Poetker</name>
+            <email>rpoetke1@jhu.edu</email>
+            <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+            <organizationUrl>https://library.jhu.edu/</organizationUrl>
+        </developer>
+    </developers>
+
+    <scm>
+        <connection>scm:git:https://github.com/eclipse-pass/pass-core.git</connection>
+        <developerConnection>scm:git:https://github.com/eclipse-pass/pass-core.git</developerConnection>
+        <url>https://github.com/eclipse-pass/pass-core</url>
+        <tag>HEAD</tag>
+    </scm>
+
     <properties>
     </properties>
 

--- a/pass-core-usertoken/pom.xml
+++ b/pass-core-usertoken/pom.xml
@@ -10,6 +10,57 @@
 
     <artifactId>pass-core-usertoken</artifactId>
 
+    <name>PASS backend-usertoken</name>
+    <description>PASS REST API implementation-usertokenn</description>
+
+    <url>https://github.com/eclipse-pass/pass-core</url>
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <name>Jim Martino</name>
+            <email>jrm@jhu.edu</email>
+            <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+            <organizationUrl>https://library.jhu.edu/</organizationUrl>
+        </developer>
+        <developer>
+            <name>Mark Patton</name>
+            <email>mpatton@jhu.edu</email>
+            <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+            <organizationUrl>https://library.jhu.edu/</organizationUrl>
+        </developer>
+        <developer>
+            <name>John Abrahams</name>
+            <email>jabrah20@jhu.edu</email>
+            <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+            <organizationUrl>https://library.jhu.edu/</organizationUrl>
+        </developer>
+        <developer>
+            <name>Tim Sanders</name>
+            <email>tsande16@jhu.edu</email>
+            <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+            <organizationUrl>https://library.jhu.edu/</organizationUrl>
+        </developer>
+        <developer>
+            <name>Russ Poetker</name>
+            <email>rpoetke1@jhu.edu</email>
+            <organization>The Sheridan Libraries, Johns Hopkins University</organization>
+            <organizationUrl>https://library.jhu.edu/</organizationUrl>
+        </developer>
+    </developers>
+
+    <scm>
+        <connection>scm:git:https://github.com/eclipse-pass/pass-core.git</connection>
+        <developerConnection>scm:git:https://github.com/eclipse-pass/pass-core.git</developerConnection>
+        <url>https://github.com/eclipse-pass/pass-core</url>
+        <tag>HEAD</tag>
+    </scm>
+
     <properties>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>
 


### PR DESCRIPTION
Apparently it is now required by sonatype central repo to duplicate a set of POM attributes in child POM files in order to publish.