### PR TITLE
Update dependencies for secops

### DIFF
--- a/pass-core-main/pom.xml
+++ b/pass-core-main/pom.xml
@@ -114,12 +114,6 @@
     <dependency>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-jakarta-server</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>commons-logging</groupId>
-          <artifactId>commons-logging</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -231,6 +231,42 @@
         <version>3.52.0</version>
       </dependency>
       <!-- End of transitive deps with convergence issues. -->
+
+      <!-- The following deps were declared to resolve CVEs from transitive deps. -->
+      <!-- These should all be checked whenever deps are upgraded. Should be removed if possible once parent -->
+      <!-- dep updates with fixed version. -->
+
+      <!-- CVE-2026-22732 -->
+      <dependency>
+          <groupId>org.springframework.security</groupId>
+          <artifactId>spring-security-web</artifactId>
+          <version>6.5.9</version>
+      </dependency>
+
+      <!-- CVE-2026-27446 -->
+      <dependency>
+          <groupId>org.apache.activemq</groupId>
+          <artifactId>artemis-jakarta-server</artifactId>
+          <version>2.53.0</version>
+          <exclusions>
+              <exclusion>
+                  <groupId>commons-logging</groupId>
+                  <artifactId>commons-logging</artifactId>
+              </exclusion>
+          </exclusions>
+      </dependency>
+      <dependency>
+          <groupId>org.apache.activemq</groupId>
+          <artifactId>artemis-jakarta-client</artifactId>
+          <version>2.53.0</version>
+          <exclusions>
+              <exclusion>
+                  <groupId>commons-logging</groupId>
+                  <artifactId>commons-logging</artifactId>
+              </exclusion>
+          </exclusions>
+      </dependency>
+      <!-- End of transitive deps with CVE issues. -->
     </dependencies>
   </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,15 @@
         <scope>import</scope>
       </dependency>
 
+        <!-- Added to fix CVE-2026-22732 -->
+      <dependency>
+        <groupId>org.springframework.security</groupId>
+        <artifactId>spring-security-bom</artifactId>
+        <version>6.5.9</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
@@ -235,13 +244,6 @@
       <!-- The following deps were declared to resolve CVEs from transitive deps. -->
       <!-- These should all be checked whenever deps are upgraded. Should be removed if possible once parent -->
       <!-- dep updates with fixed version. -->
-
-      <!-- CVE-2026-22732 -->
-      <dependency>
-          <groupId>org.springframework.security</groupId>
-          <artifactId>spring-security-web</artifactId>
-          <version>6.5.9</version>
-      </dependency>
 
       <!-- CVE-2026-27446 -->
       <dependency>


### PR DESCRIPTION
This PR upgrades a couple dependencies to resolve Critical CVEs in those third party dependencies.

The spring security one is more critical. Activemq artemis is only used for testing purposes.